### PR TITLE
Helper Methods for Handling REST & JSON-Body Arguments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
             - run: ./setupenv.sh
             - run: |
                 . env/bin/activate &&
-                pytest --tb=short
+                pytest -vvvvv --tb=short
 workflows:
     version: 2
     build_and_test:

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+src/

--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -14,13 +14,14 @@ class _NoDefaultValue:  # pylint: disable=R0903
     """Signal no default value, AKA argument is required."""
 
 
+NO_DEFAULT = _NoDefaultValue()
+
+
 class ArgumentHandler:
     """Helper class for argument parsing, defaulting, and casting.
 
     Like argparse.ArgumentParser, but for REST & JSON-body arguments.
     """
-
-    NO_DEFAULT = _NoDefaultValue()
 
     @staticmethod
     def _qualify_argument(
@@ -73,7 +74,7 @@ class ArgumentHandler:
             return ArgumentHandler._qualify_argument(type_, choices, val)
         except (KeyError, json.decoder.JSONDecodeError):
             # Required -> raise 400
-            if isinstance(default, type(ArgumentHandler.NO_DEFAULT)):
+            if isinstance(default, type(NO_DEFAULT)):
                 raise tornado.web.MissingArgumentError(name)
 
         # Else:
@@ -97,7 +98,7 @@ class ArgumentHandler:
         """
         # If:
         # Required -> raise 400
-        if isinstance(default, type(ArgumentHandler.NO_DEFAULT)):
+        if isinstance(default, type(NO_DEFAULT)):
             # check JSON'd body arguments
             try:
                 return ArgumentHandler.get_json_body_argument(

--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -100,10 +100,10 @@ class ArgumentHandler:
         # If:
         # Required -> raise 400
         if isinstance(default, type(NO_DEFAULT)):
-            # check JSON'd body arguments
+            # check JSON-body arguments
             try:
                 json_arg = ArgumentHandler.get_json_body_argument(
-                    request_handler, name, default, choices
+                    request_handler, name, NO_DEFAULT, choices
                 )
                 return ArgumentHandler._qualify_argument(type_, choices, json_arg)
             except tornado.web.MissingArgumentError:
@@ -118,12 +118,14 @@ class ArgumentHandler:
         # Else:
         # Optional / Default
         ArgumentHandler._type_check(type_, default)
-        # check JSON'd body arguments  # pylint: disable=C0103
-        json_arg = ArgumentHandler.get_json_body_argument(
-            request_handler, name, default, choices,
-        )
-        if json_arg != default:
+        # check JSON-body arguments
+        try:  # DON'T pass `default` b/c we want to know if there ISN'T a value
+            json_arg = ArgumentHandler.get_json_body_argument(
+                request_handler, name, NO_DEFAULT, choices
+            )
             return ArgumentHandler._qualify_argument(type_, choices, json_arg)
+        except tornado.web.MissingArgumentError:
+            pass
         # check query and body arguments
         arg = request_handler.get_argument(name, default, strip=strip)
         return ArgumentHandler._qualify_argument(type_, choices, arg)

--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -85,7 +85,7 @@ class ArgumentHandler:
         except (KeyError, json.decoder.JSONDecodeError):
             # Required -> raise 400
             if isinstance(default, type(NO_DEFAULT)):
-                raise tornado.web.MissingArgumentError(name)
+                raise _make_400_error(name, tornado.web.MissingArgumentError(name))
         except _UnqualifiedArgumentError as e:
             raise _make_400_error(name, e)
 

--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -18,9 +18,15 @@ class _NoDefaultValue:  # pylint: disable=R0903
 NO_DEFAULT = _NoDefaultValue()
 
 
-def _get_json_body(request_handler: tornado.web.RequestHandler) -> Dict[str, Any]:
+def _get_json_body_arguments(
+    request_handler: tornado.web.RequestHandler,
+) -> Dict[str, Any]:
+    """Return the request body JSON-decoded, but only if it's a `dict`."""
     json_body = json_decode(request_handler.request.body)  # type: ignore[no-untyped-call]
-    return cast(Dict[str, Any], json_body)
+
+    if isinstance(json, dict):
+        return cast(Dict[str, Any], json_body)
+    return {}
 
 
 class _UnqualifiedArgumentError(Exception):
@@ -82,7 +88,7 @@ class ArgumentHandler:
     ) -> Any:
         """Return the argument from JSON-decoded request body."""
         try:
-            value = _get_json_body(request_handler)[name]
+            value = _get_json_body_arguments(request_handler)[name]
             return ArgumentHandler._qualify_argument(None, choices, value)
         except (KeyError, json.decoder.JSONDecodeError):
             # Required -> raise 400

--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -2,7 +2,7 @@
 
 
 import json
-from typing import Any, List, Optional
+from typing import Any, cast, Dict, List, Optional
 
 import tornado.web
 
@@ -16,6 +16,11 @@ class _NoDefaultValue:  # pylint: disable=R0903
 
 NO_DEFAULT = _NoDefaultValue()
 _FALSES = ["FALSE", "False", "false", "0", 0, "NO", "No", "no"]
+
+
+def _get_json_body(request_handler: tornado.web.RequestHandler) -> Dict[str, Any]:
+    json_body = json_decode(request_handler.request.body)  # type: ignore[no-untyped-call]
+    return cast(Dict[str, Any], json_body)
 
 
 class ArgumentHandler:
@@ -69,7 +74,7 @@ class ArgumentHandler:
     ) -> Any:
         """Return the argument by JSON-decoding the request body."""
         try:
-            value = json_decode(request_handler.request.body)[name]  # type: ignore[no-untyped-call]
+            value = _get_json_body(request_handler)[name]
             if strip and isinstance(value, tornado.util.unicode_type):
                 value = value.strip()
             return ArgumentHandler._qualify_argument(type_, choices, value)

--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -24,7 +24,7 @@ def _get_json_body_arguments(
     """Return the request body JSON-decoded, but only if it's a `dict`."""
     json_body = json_decode(request_handler.request.body)  # type: ignore[no-untyped-call]
 
-    if isinstance(json, dict):
+    if isinstance(json_body, dict):
         return cast(Dict[str, Any], json_body)
     return {}
 

--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -15,6 +15,7 @@ class _NoDefaultValue:  # pylint: disable=R0903
 
 
 NO_DEFAULT = _NoDefaultValue()
+_FALSES = ["FALSE", "False", "false", "0", 0, "NO", "No", "no"]
 
 
 class ArgumentHandler:
@@ -27,13 +28,13 @@ class ArgumentHandler:
     def _qualify_argument(
         type_: Optional[type], choices: Optional[List[Any]], value: Any
     ) -> Any:
-        """Cast `val` to `type_` type, and/or check that `val` in in `choices`.
+        """Cast `value` to `type_` type, and/or check `value` in in `choices`.
 
         Raise 400 if either qualification fails.
         """
         if type_:
             try:
-                if (type_ == bool) and (value == "False"):
+                if (type_ == bool) and (value in _FALSES):
                     value = False
                 else:
                     value = type_(value)
@@ -68,10 +69,10 @@ class ArgumentHandler:
     ) -> Any:
         """Return the argument by JSON-decoding the request body."""
         try:
-            val = json_decode(request_handler.request.body)[name]  # type: ignore[no-untyped-call]
-            if strip and isinstance(val, tornado.util.unicode_type):
-                val = val.strip()
-            return ArgumentHandler._qualify_argument(type_, choices, val)
+            value = json_decode(request_handler.request.body)[name]  # type: ignore[no-untyped-call]
+            if strip and isinstance(value, tornado.util.unicode_type):
+                value = value.strip()
+            return ArgumentHandler._qualify_argument(type_, choices, value)
         except (KeyError, json.decoder.JSONDecodeError):
             # Required -> raise 400
             if isinstance(default, type(NO_DEFAULT)):

--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -29,7 +29,7 @@ class _UnqualifiedArgumentError(Exception):
 
 def _make_400_error(arg_name: str, error: Exception) -> tornado.web.HTTPError:
     if isinstance(error, tornado.web.MissingArgumentError):
-        return error
+        return error  # MissingArgumentError is already a 400 error
     return tornado.web.HTTPError(400, reason=f"`{arg_name}`: {error}")
 
 

--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -1,6 +1,7 @@
 """Handle argument parsing, defaulting, and casting."""
 
 
+import distutils.util
 import json
 from typing import Any, cast, Dict, List, Optional
 
@@ -15,7 +16,6 @@ class _NoDefaultValue:  # pylint: disable=R0903
 
 
 NO_DEFAULT = _NoDefaultValue()
-_FALSES = ["FALSE", "False", "false", "0", 0, "NO", "No", "no"]
 
 
 def _get_json_body(request_handler: tornado.web.RequestHandler) -> Dict[str, Any]:
@@ -49,8 +49,8 @@ class ArgumentHandler:
         """
         if type_:
             try:
-                if (type_ == bool) and (value in _FALSES):
-                    value = False
+                if isinstance(value, str) and (type_ == bool) and (value != ""):
+                    value = bool(distutils.util.strtobool(value))
                 else:
                     value = type_(value)
             except ValueError as e:

--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -28,6 +28,8 @@ class _UnqualifiedArgumentError(Exception):
 
 
 def _make_400_error(arg_name: str, error: Exception) -> tornado.web.HTTPError:
+    if isinstance(error, tornado.web.MissingArgumentError):
+        return error
     return tornado.web.HTTPError(400, reason=f"`{arg_name}`: {error}")
 
 

--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -80,7 +80,7 @@ class ArgumentHandler:
         default: Any,
         choices: Optional[List[Any]],
     ) -> Any:
-        """Return the argument by JSON-decoding the request body."""
+        """Return the argument from JSON-decoded request body."""
         try:
             value = _get_json_body(request_handler)[name]
             return ArgumentHandler._qualify_argument(None, choices, value)
@@ -107,7 +107,7 @@ class ArgumentHandler:
         type_: Optional[type],
         choices: Optional[List[Any]],
     ) -> Any:
-        """Return argument. If no default provided raise 400 if not present.
+        """Return argument from query arguments or JSON request body.
 
         Try from `get_json_body_argument()` first, then from
         `request_handler.get_argument()`.

--- a/rest_tools/server/argument_handler.py
+++ b/rest_tools/server/argument_handler.py
@@ -1,0 +1,127 @@
+"""Handle argument parsing, defaulting, and casting."""
+
+
+import json
+from typing import Any, List, Optional
+
+import tornado.web
+
+# local imports
+from rest_tools.client.json_util import json_decode
+
+
+class _NoDefaultValue:  # pylint: disable=R0903
+    """Signal no default value, AKA argument is required."""
+
+
+NO_DEFAULT = _NoDefaultValue()
+
+
+class ArgumentHandler:
+    """Helper class for argument parsing, defaulting, and casting.
+
+    Like argparse.ArgumentParser, but for REST & JSON-body arguments.
+    """
+
+    @staticmethod
+    def _qualify_argument(
+        type_: Optional[type], choices: Optional[List[Any]], value: Any
+    ) -> Any:
+        """Cast `val` to `type_` type, and/or check that `val` in in `choices`.
+
+        Raise 400 if either qualification fails.
+        """
+        if type_:
+            try:
+                if (type_ == bool) and (value == "False"):
+                    value = False
+                else:
+                    value = type_(value)
+            except ValueError as e:
+                raise tornado.web.HTTPError(400, reason=f"(ValueError) {e}")
+
+        if choices and (value not in choices):
+            raise tornado.web.HTTPError(
+                400, reason=f"(ValueError) {value} not in options ({choices})"
+            )
+
+        return value
+
+    @staticmethod
+    def _type_check(type_: Optional[type], value: Any) -> None:
+        # check the value's type (None is okay too)
+        if not type_:
+            return
+        if not isinstance(value, type_) and (value is not None):
+            raise ValueError(
+                f"Value, `{value}` ({type(value)}), is not {type_} or None"
+            )
+
+    @staticmethod
+    def get_json_body_argument(  # pylint: disable=R0913
+        request_handler: tornado.web.RequestHandler,
+        name: str,
+        default: Any,
+        strip: bool,
+        type_: Optional[type],
+        choices: Optional[List[Any]],
+    ) -> Any:
+        """Return the argument by JSON-decoding the request body."""
+        try:
+            val = json_decode(request_handler.request.body)[name]  # type: ignore[no-untyped-call]
+            if strip and isinstance(val, tornado.util.unicode_type):
+                val = val.strip()
+            return ArgumentHandler._qualify_argument(type_, choices, val)
+        except (KeyError, json.decoder.JSONDecodeError):
+            # Required -> raise 400
+            if isinstance(default, type(NO_DEFAULT)):
+                raise tornado.web.MissingArgumentError(name)
+
+        # Else:
+        # Optional / Default
+        ArgumentHandler._type_check(type_, default)
+        return ArgumentHandler._qualify_argument(type_, choices, default)
+
+    @staticmethod
+    def get_argument(  # pylint: disable=W0221,R0913
+        request_handler: tornado.web.RequestHandler,
+        name: str,
+        default: Any,
+        strip: bool,
+        type_: Optional[type],
+        choices: Optional[List[Any]],
+    ) -> Any:
+        """Return argument. If no default provided raise 400 if not present.
+
+        Try from `get_json_body_argument()` first, then from
+        `request_handler.get_argument()`.
+        """
+        # If:
+        # Required -> raise 400
+        if isinstance(default, type(NO_DEFAULT)):
+            # check JSON'd body arguments
+            try:
+                return ArgumentHandler.get_json_body_argument(
+                    request_handler, name, default, strip, type_, choices
+                )
+            except tornado.web.MissingArgumentError:
+                pass
+            # check query and body arguments
+            try:
+                arg = request_handler.get_argument(name, strip=strip)
+                return ArgumentHandler._qualify_argument(type_, choices, arg)
+            except tornado.web.MissingArgumentError as e:
+                raise tornado.web.HTTPError(400, reason=e.log_message)
+
+        # Else:
+        # Optional / Default
+        ArgumentHandler._type_check(type_, default)
+        # check JSON'd body arguments  # pylint: disable=C0103
+        json_arg = ArgumentHandler.get_json_body_argument(
+            request_handler, name, default, strip, type_, choices,
+        )
+        if json_arg != default:
+            return json_arg
+        # check query and body arguments
+        arg = request_handler.get_argument(name, default, strip=strip)
+        return ArgumentHandler._qualify_argument(type_, choices, arg)

--- a/rest_tools/server/argument_handler.py
+++ b/rest_tools/server/argument_handler.py
@@ -14,14 +14,13 @@ class _NoDefaultValue:  # pylint: disable=R0903
     """Signal no default value, AKA argument is required."""
 
 
-NO_DEFAULT = _NoDefaultValue()
-
-
 class ArgumentHandler:
     """Helper class for argument parsing, defaulting, and casting.
 
     Like argparse.ArgumentParser, but for REST & JSON-body arguments.
     """
+
+    NO_DEFAULT = _NoDefaultValue()
 
     @staticmethod
     def _qualify_argument(
@@ -74,7 +73,7 @@ class ArgumentHandler:
             return ArgumentHandler._qualify_argument(type_, choices, val)
         except (KeyError, json.decoder.JSONDecodeError):
             # Required -> raise 400
-            if isinstance(default, type(NO_DEFAULT)):
+            if isinstance(default, type(ArgumentHandler.NO_DEFAULT)):
                 raise tornado.web.MissingArgumentError(name)
 
         # Else:
@@ -98,7 +97,7 @@ class ArgumentHandler:
         """
         # If:
         # Required -> raise 400
-        if isinstance(default, type(NO_DEFAULT)):
+        if isinstance(default, type(ArgumentHandler.NO_DEFAULT)):
             # check JSON'd body arguments
             try:
                 return ArgumentHandler.get_json_body_argument(

--- a/rest_tools/server/handler.py
+++ b/rest_tools/server/handler.py
@@ -8,6 +8,7 @@ import logging
 import time
 from collections import defaultdict
 from functools import partial, wraps
+from typing import Any, List, Optional
 
 import tornado.gen
 import tornado.httpclient
@@ -16,6 +17,7 @@ import tornado.web
 # local imports
 import rest_tools
 
+from .argument_handler import ArgumentHandler
 from .auth import Auth, OpenIDAuth
 from .stats import RouteStats
 
@@ -142,6 +144,37 @@ class RestHandler(tornado.web.RequestHandler):
         }
         self.write(data)
         self.finish()
+
+    def get_json_body_argument(  # pylint: disable=R0913
+        self,
+        name: str,
+        default: Any = ArgumentHandler.NO_DEFAULT,
+        strip: bool = True,
+        type_: Optional[type] = None,
+        choices: Optional[List[Any]] = None,
+    ) -> Any:
+        """Return the argument by JSON-decoding the request body."""
+        return ArgumentHandler.get_json_body_argument(
+            super(), name, default, strip, type_, choices
+        )
+
+
+    @staticmethod
+    def get_argument(  # pylint: disable=W0221,R0913
+        self,
+        name: str,
+        default: Any = ArgumentHandler.NO_DEFAULT,
+        strip: bool = True,
+        type_: Optional[type] = None,
+        choices: Optional[List[Any]] = None,
+    ) -> Any:
+        """Return argument.
+
+        If no default provided raise 400 if not present.
+        """
+        return ArgumentHandler.get_argument(
+            super(), name, default, strip, type_, choices
+        )
 
 
 def authenticated(method):

--- a/rest_tools/server/handler.py
+++ b/rest_tools/server/handler.py
@@ -10,7 +10,7 @@ import tornado.gen
 import tornado.httpclient
 from tornado.platform.asyncio import to_asyncio_future
 
-from rest_tools.client import json_decode  # type: ignore
+from rest_tools.json_util import json_decode  # type: ignore
 from .auth import Auth, OpenIDAuth
 from .stats import RouteStats
 import rest_tools

--- a/rest_tools/server/handler.py
+++ b/rest_tools/server/handler.py
@@ -176,6 +176,7 @@ class RestHandler(tornado.web.RequestHandler):
                 if isinstance(default, NoDefualtValue):
                     raise tornado.web.MissingArgumentError(name)
 
+        # Else:
         # Optional / Default
         if type_:
             assert isinstance(default, type_) or (default is None)
@@ -193,19 +194,26 @@ class RestHandler(tornado.web.RequestHandler):
         Try from `self.get_json_body_argument()` first, then from
         `super().get_argument()`.
         """
+        # If:
         # Required -> raise 400
         if isinstance(default, NoDefualtValue):
+            # check JSON'd body arguments
             try:
                 return _cast(type_, self.get_json_body_argument(name, strip=strip))
             except tornado.web.MissingArgumentError:
                 pass
+            # check query and body arguments
             return _cast(type_, super().get_argument(name, strip=strip))
 
+        # Else:
         # Optional / Default
         if type_:
             assert isinstance(default, type_) or (default is None)
-        if j_val := self.get_json_body_argument(name, default=default, strip=strip, type_=type_) != default:
-            return j_val
+        # check JSON'd body arguments  # pylint: disable=C0103
+        j = self.get_json_body_argument(name, default=default, strip=strip, type_=type_)
+        if j != default:
+            return j
+        # check query and body arguments
         return _cast(type_, super().get_argument(name, default=default, strip=strip))
 
 

--- a/rest_tools/server/handler.py
+++ b/rest_tools/server/handler.py
@@ -17,7 +17,7 @@ import tornado.web
 # local imports
 import rest_tools
 
-from .argument_handler import ArgumentHandler
+from . import arghandler
 from .auth import Auth, OpenIDAuth
 from .stats import RouteStats
 
@@ -148,20 +148,20 @@ class RestHandler(tornado.web.RequestHandler):
     def get_json_body_argument(  # pylint: disable=R0913
         self,
         name: str,
-        default: Any = ArgumentHandler.NO_DEFAULT,
+        default: Any = arghandler.NO_DEFAULT,
         strip: bool = True,
         type_: Optional[type] = None,
         choices: Optional[List[Any]] = None,
     ) -> Any:
         """Return the argument by JSON-decoding the request body."""
-        return ArgumentHandler.get_json_body_argument(
+        return arghandler.ArgumentHandler.get_json_body_argument(
             super(), name, default, strip, type_, choices
         )
 
     def get_argument(  # pylint: disable=W0221,R0913
         self,
         name: str,
-        default: Any = ArgumentHandler.NO_DEFAULT,
+        default: Any = arghandler.NO_DEFAULT,
         strip: bool = True,
         type_: Optional[type] = None,
         choices: Optional[List[Any]] = None,
@@ -170,7 +170,7 @@ class RestHandler(tornado.web.RequestHandler):
 
         If no default provided raise 400 if not present.
         """
-        return ArgumentHandler.get_argument(
+        return arghandler.ArgumentHandler.get_argument(
             super(), name, default, strip, type_, choices
         )
 

--- a/rest_tools/server/handler.py
+++ b/rest_tools/server/handler.py
@@ -158,8 +158,6 @@ class RestHandler(tornado.web.RequestHandler):
             super(), name, default, strip, type_, choices
         )
 
-
-    @staticmethod
     def get_argument(  # pylint: disable=W0221,R0913
         self,
         name: str,

--- a/rest_tools/server/handler.py
+++ b/rest_tools/server/handler.py
@@ -140,7 +140,7 @@ class RestHandler(tornado.web.RequestHandler):
         """Return argument, or default value if not present.
 
         Try from `self.request.body` first, then from
-        `self.get_query_argument()`.
+        `self.get_argument()`.
         """
         try:
             return self.get_required_argument(name)
@@ -151,7 +151,7 @@ class RestHandler(tornado.web.RequestHandler):
         """Return argument, raise 400 if not present.
 
         Try from `self.request.body` first, then from
-        `self.get_query_argument()`.
+        `self.get_argument()`.
         """
         if self.request.body:
             try:

--- a/rest_tools/server/handler.py
+++ b/rest_tools/server/handler.py
@@ -145,18 +145,31 @@ class RestHandler(tornado.web.RequestHandler):
         self.write(data)
         self.finish()
 
-    def get_json_body_argument(  # pylint: disable=R0913
+    def get_json_body_argument(
         self,
         name: str,
         default: Any = arghandler.NO_DEFAULT,
         choices: Optional[List[Any]] = None,
     ) -> Any:
-        """Return the argument by JSON-decoding the request body."""
+        """Return the argument from JSON-decoded request body.
+
+        If no `default` is provided, and the argument is not present, raise `400`.
+
+        Arguments:
+            name -- the argument's name
+
+        Keyword Arguments:
+            default -- a default value to use if the argument is not present
+            choices -- a list of valid argument values (raise `400`, if arg's value is not in list)
+
+        Returns:
+            Any -- the argument's value, unaltered
+        """
         return arghandler.ArgumentHandler.get_json_body_argument(
             super(), name, default, choices
         )
 
-    def get_argument(  # pylint: disable=W0221,R0913
+    def get_argument(
         self,
         name: str,
         default: Any = arghandler.NO_DEFAULT,
@@ -164,9 +177,21 @@ class RestHandler(tornado.web.RequestHandler):
         type_: Optional[type] = None,
         choices: Optional[List[Any]] = None,
     ) -> Any:
-        """Return argument.
+        """Return argument from query arguments or JSON-decoded request body.
 
-        If no default provided raise 400 if not present.
+        If no `default` is provided, and the argument is not present, raise `400`.
+
+        Arguments:
+            name -- the argument's name
+
+        Keyword Arguments:
+            default -- a default value to use if the argument is not present
+            strip {`bool`} -- whether to `str.strip()` the arg's value (default: {`True`})
+            type_ -- optionally, type-cast the argument's value (raise `400` on `TypeError`)
+            choices -- a list of valid argument values (raise `400`, if arg's value is not in list)
+
+        Returns:
+            Any -- the argument's value, possibly stripped/type-casted
         """
         return arghandler.ArgumentHandler.get_argument(
             super(), name, default, strip, type_, choices

--- a/rest_tools/server/handler.py
+++ b/rest_tools/server/handler.py
@@ -10,7 +10,7 @@ import tornado.gen
 import tornado.httpclient
 from tornado.platform.asyncio import to_asyncio_future
 
-from rest_tools.json_util import json_decode  # type: ignore
+from rest_tools.client.json_util import json_decode  # type: ignore
 from .auth import Auth, OpenIDAuth
 from .stats import RouteStats
 import rest_tools

--- a/rest_tools/server/handler.py
+++ b/rest_tools/server/handler.py
@@ -159,7 +159,7 @@ class RestHandler(tornado.web.RequestHandler):
             except KeyError:
                 pass
         try:
-            return self.get_query_argument(name)
+            return self.get_argument(name)
         except tornado.web.MissingArgumentError:
             pass
         # fall-through

--- a/rest_tools/server/handler.py
+++ b/rest_tools/server/handler.py
@@ -1,21 +1,26 @@
-import logging
-import json
-import time
-from functools import wraps, update_wrapper, partialmethod, partial
-from collections import defaultdict
-from typing import Any, Optional
+"""RestHandler and related classes."""
 
-import tornado.web
+# fmt:off
+# mypy: ignore-errors
+# pylint: skip-file
+
+import logging
+import time
+from collections import defaultdict
+from functools import partial, wraps
+
 import tornado.gen
 import tornado.httpclient
-from tornado.platform.asyncio import to_asyncio_future
+import tornado.web
 
-from rest_tools.client.json_util import json_decode  # type: ignore
-from .auth import Auth, OpenIDAuth
-from .stats import RouteStats
+# local imports
 import rest_tools
 
+from .auth import Auth, OpenIDAuth
+from .stats import RouteStats
+
 logger = logging.getLogger('rest')
+
 
 def RestHandlerSetup(config={}):
     """
@@ -75,12 +80,12 @@ class RestHandler(tornado.web.RequestHandler):
     def __init__(self, *args, **kwargs):
         self.server_header = ''
         try:
-            super(RestHandler, self).__init__(*args, **kwargs)
+            super().__init__(*args, **kwargs)
         except Exception:
             logging.error('error', exc_info=True)
 
     def initialize(self, debug=False, auth=None, auth_url=None, module_auth_key='', server_header='', route_stats=None, **kwargs):
-        super(RestHandler, self).initialize(**kwargs)
+        super().initialize(**kwargs)
         self.debug = debug
         self.auth = auth
         self.auth_url = auth_url
@@ -94,7 +99,7 @@ class RestHandler(tornado.web.RequestHandler):
         self._headers['Server'] = self.server_header
 
     def get_template_namespace(self):
-        namespace = super(RESTHandler,self).get_template_namespace()
+        namespace = super().get_template_namespace()
         namespace['version'] = rest_tools.__version__
         return namespace
 
@@ -157,6 +162,7 @@ def authenticated(method):
         return await method(self, *args, **kwargs)
     return wrapper
 
+
 def catch_error(method):
     """
     Decorator to catch and handle errors on handlers.
@@ -180,6 +186,7 @@ def catch_error(method):
             message = 'Error in '+self.__class__.__name__
             self.send_error(500, reason=message)
     return wrapper
+
 
 def role_authorization(**_auth):
     """
@@ -219,6 +226,7 @@ def role_authorization(**_auth):
             return await method(self, *args, **kwargs)
         return wrapper
     return make_wrapper
+
 
 def scope_role_auth(**_auth):
     """

--- a/rest_tools/server/handler.py
+++ b/rest_tools/server/handler.py
@@ -149,13 +149,11 @@ class RestHandler(tornado.web.RequestHandler):
         self,
         name: str,
         default: Any = arghandler.NO_DEFAULT,
-        strip: bool = True,
-        type_: Optional[type] = None,
         choices: Optional[List[Any]] = None,
     ) -> Any:
         """Return the argument by JSON-decoding the request body."""
         return arghandler.ArgumentHandler.get_json_body_argument(
-            super(), name, default, strip, type_, choices
+            super(), name, default, choices
         )
 
     def get_argument(  # pylint: disable=W0221,R0913

--- a/tests/server/arghandler_test.py
+++ b/tests/server/arghandler_test.py
@@ -2,14 +2,17 @@
 
 # pylint: disable=W0212
 
-from typing import Any
 from unittest.mock import ANY, Mock, patch
 
 import pytest
 import tornado.web
 
 # local imports
-from rest_tools.server.arghandler import ArgumentHandler, NO_DEFAULT
+from rest_tools.server.arghandler import (
+    _UnqualifiedArgumentError,
+    ArgumentHandler,
+    NO_DEFAULT,
+)
 
 
 def test_00_qualify_argument() -> None:
@@ -52,36 +55,29 @@ def test_00_qualify_argument() -> None:
 def test_01_qualify_argument_errors() -> None:
     """Test `_qualify_argument()`."""
     # Test Types:
-    with pytest.raises(tornado.web.HTTPError) as e:
+    with pytest.raises(_UnqualifiedArgumentError) as e:
         ArgumentHandler._qualify_argument(int, [], "")
     assert "(ValueError)" in str(e.value)
-    assert "400" in str(e.value)
-    with pytest.raises(tornado.web.HTTPError) as e:
+    with pytest.raises(_UnqualifiedArgumentError) as e:
         ArgumentHandler._qualify_argument(float, [], "")
     assert "(ValueError)" in str(e.value)
-    assert "400" in str(e.value)
-    with pytest.raises(tornado.web.HTTPError) as e:
+    with pytest.raises(_UnqualifiedArgumentError) as e:
         ArgumentHandler._qualify_argument(float, [], "123abc")
     assert "(ValueError)" in str(e.value)
-    assert "400" in str(e.value)
 
     # Test Choices:
-    with pytest.raises(tornado.web.HTTPError) as e:
+    with pytest.raises(_UnqualifiedArgumentError) as e:
         ArgumentHandler._qualify_argument(None, [23], "23")
     assert "(ValueError)" in str(e.value) and "not in options" in str(e.value)
-    assert "400" in str(e.value)
-    with pytest.raises(tornado.web.HTTPError) as e:
+    with pytest.raises(_UnqualifiedArgumentError) as e:
         ArgumentHandler._qualify_argument(str, ["STRING"], "string")
     assert "(ValueError)" in str(e.value) and "not in options" in str(e.value)
-    assert "400" in str(e.value)
-    with pytest.raises(tornado.web.HTTPError) as e:
+    with pytest.raises(_UnqualifiedArgumentError) as e:
         ArgumentHandler._qualify_argument(int, [0, 1, 2], "3")
     assert "(ValueError)" in str(e.value) and "not in options" in str(e.value)
-    assert "400" in str(e.value)
-    with pytest.raises(tornado.web.HTTPError) as e:
+    with pytest.raises(_UnqualifiedArgumentError) as e:
         ArgumentHandler._qualify_argument(list, [["a", "b", "c", "d"]], "abc")
     assert "(ValueError)" in str(e.value) and "not in options" in str(e.value)
-    assert "400" in str(e.value)
 
 
 def test_10_type_check() -> None:

--- a/tests/server/arghandler_test.py
+++ b/tests/server/arghandler_test.py
@@ -1,0 +1,47 @@
+"""Test server/arghandler.py."""
+
+
+def test_qualify_argument() -> None:
+    """Test `_qualify_argument()`."""
+    pass
+
+
+def test_type_check() -> None:
+    """Test `_type_check()`."""
+    pass
+
+
+def test_get_argument_no_body_00() -> None:
+    """Test `request.arguments`/`RequestHandler.get_argument()` arguments.
+
+    No tests for body-parsing.
+    """
+    pass
+
+
+def test_get_argument_no_body_01() -> None:
+    """Test `request.arguments`/`RequestHandler.get_argument()` arguments.
+
+    No tests for body-parsing.
+    """
+    pass
+
+
+def test_get_json_body_argument_00() -> None:
+    """Test `request.body` JSON arguments."""
+    pass
+
+
+def test_get_json_body_argument_01() -> None:
+    """Test `request.body` JSON arguments."""
+    pass
+
+
+def test_get_argument_args_and_body_00() -> None:
+    """Test `get_argument()`."""
+    pass
+
+
+def test_get_argument_args_and_body_01() -> None:
+    """Test `get_argument()`."""
+    pass

--- a/tests/server/arghandler_test.py
+++ b/tests/server/arghandler_test.py
@@ -55,26 +55,33 @@ def test_01_qualify_argument_errors() -> None:
     with pytest.raises(tornado.web.HTTPError) as e:
         ArgumentHandler._qualify_argument(int, [], "")
     assert "(ValueError)" in str(e.value)
+    assert "400" in str(e.value)
     with pytest.raises(tornado.web.HTTPError) as e:
         ArgumentHandler._qualify_argument(float, [], "")
     assert "(ValueError)" in str(e.value)
+    assert "400" in str(e.value)
     with pytest.raises(tornado.web.HTTPError) as e:
         ArgumentHandler._qualify_argument(float, [], "123abc")
     assert "(ValueError)" in str(e.value)
+    assert "400" in str(e.value)
 
     # Test Choices:
     with pytest.raises(tornado.web.HTTPError) as e:
         ArgumentHandler._qualify_argument(None, [23], "23")
     assert "(ValueError)" in str(e.value) and "not in options" in str(e.value)
+    assert "400" in str(e.value)
     with pytest.raises(tornado.web.HTTPError) as e:
         ArgumentHandler._qualify_argument(str, ["STRING"], "string")
     assert "(ValueError)" in str(e.value) and "not in options" in str(e.value)
+    assert "400" in str(e.value)
     with pytest.raises(tornado.web.HTTPError) as e:
         ArgumentHandler._qualify_argument(int, [0, 1, 2], "3")
     assert "(ValueError)" in str(e.value) and "not in options" in str(e.value)
+    assert "400" in str(e.value)
     with pytest.raises(tornado.web.HTTPError) as e:
         ArgumentHandler._qualify_argument(list, [["a", "b", "c", "d"]], "abc")
     assert "(ValueError)" in str(e.value) and "not in options" in str(e.value)
+    assert "400" in str(e.value)
 
 
 def test_10_type_check() -> None:
@@ -104,20 +111,58 @@ def test_10_type_check() -> None:
                 ArgumentHandler._type_check(o_type, val)
 
 
-def test_20_get_argument_no_body() -> None:
+@patch("rest_tools.server.arghandler._get_json_body")
+@patch("tornado.web.RequestHandler")
+def test_20_get_argument_no_body(twrh: Mock, gjb: Mock) -> None:
     """Test `request.arguments`/`RequestHandler.get_argument()` arguments.
 
     No tests for body-parsing.
     """
-    pass
+    args = {
+        "foo": ("-10", int),
+        "bar": ("True", bool),
+        "bat": ("2.5", float),
+        "baz": ("Toyota Corolla", str),
+        "boo": ("False", bool),
+    }
+
+    for arg, (val, type_) in args.items():
+        # pylint: disable=E1102
+        print(arg)
+        print(val)
+        print(type_)
+        # w/o typing
+        gjb.return_value = {}
+        twrh.get_argument.return_value = val
+        ret = ArgumentHandler.get_argument(twrh, arg, None, False, None, [])
+        assert ret == val
+        # w/ typing
+        gjb.return_value = {}
+        twrh.get_argument.return_value = val
+        ret = ArgumentHandler.get_argument(twrh, arg, None, False, type_, [])
+        assert ret == type_(val) or (val == "False" and ret is False and type_ == bool)
+
+    # NOTE - `default` non-error use-cases solely on RequestHandler.get_argument(), so no tests
+    # NOTE - `strip` use-cases depend solely on RequestHandler.get_argument(), so no tests
+    # NOTE - `choices` use-cases are tested in `_qualify_argument` tests
 
 
-def test_21_get_argument_no_body() -> None:
+@patch("rest_tools.server.arghandler._get_json_body")
+@patch("tornado.web.RequestHandler")
+def test_21_get_argument_no_body_errors(twrh: Mock, gjb: Mock) -> None:
     """Test `request.arguments`/`RequestHandler.get_argument()` arguments.
 
     No tests for body-parsing.
     """
-    pass
+    # Missing Required Argument
+    with pytest.raises(tornado.web.HTTPError) as e:
+        gjb.return_value = {}
+        twrh.get_argument.side_effect = tornado.web.MissingArgumentError("Reqd")
+        ArgumentHandler.get_argument(twrh, "Reqd", NO_DEFAULT, False, None, [])
+    assert "Reqd" in str(e.value)
+    assert "400" in str(e.value)
+
+    # NOTE - `type_` and `choices` are tested in `_qualify_argument` tests
 
 
 @patch("rest_tools.server.arghandler._get_json_body")
@@ -137,7 +182,7 @@ def test_30_get_json_body_argument(gjb: Mock) -> None:
         ret = ArgumentHandler.get_json_body_argument(ANY, arg, "Terry", [])
         assert ret == "Terry"
 
-    # NOTE - `choices` use-cases are tested `_qualify_argument` tests
+    # NOTE - `choices` use-cases are tested in `_qualify_argument` tests
 
 
 @patch("rest_tools.server.arghandler._get_json_body")
@@ -151,12 +196,14 @@ def test_31_get_json_body_argument_errors(gjb: Mock) -> None:
         ArgumentHandler.get_json_body_argument(ANY, "Reqd", NO_DEFAULT, [])
     assert "Reqd" in str(e.value)
 
+    # NOTE - `choices` use-cases are tested in `_qualify_argument` tests
+
 
 def test_40_get_argument_args_and_body() -> None:
     """Test `get_argument()`."""
     pass
 
-    # NOTE - `type_` and `choices` are tested `_qualify_argument` tests
+    # NOTE - `type_` and `choices` are tested in `_qualify_argument` tests
 
 
 def test_41_get_argument_args_and_body_errors() -> None:

--- a/tests/server/arghandler_test.py
+++ b/tests/server/arghandler_test.py
@@ -1,17 +1,85 @@
 """Test server/arghandler.py."""
 
+# pylint: disable=W0212
 
-def test_qualify_argument() -> None:
+import pytest
+import tornado.web
+
+# local imports
+from rest_tools.server.arghandler import ArgumentHandler
+
+
+def test_00_qualify_argument() -> None:
     """Test `_qualify_argument()`."""
-    pass
+    # Test Types:
+    # None - no casting
+    assert ArgumentHandler._qualify_argument(None, [], "string") == "string"
+    assert ArgumentHandler._qualify_argument(None, [], "0") == "0"
+    assert ArgumentHandler._qualify_argument(None, [], "2.5") == "2.5"
+    # str
+    assert ArgumentHandler._qualify_argument(str, [], "string") == "string"
+    assert ArgumentHandler._qualify_argument(str, [], "") == ""
+    assert ArgumentHandler._qualify_argument(str, [], 0) == "0"
+    # int
+    assert ArgumentHandler._qualify_argument(int, [], "1") == 1
+    assert ArgumentHandler._qualify_argument(int, [], "1") != "1"
+    # float
+    assert ArgumentHandler._qualify_argument(float, [], "2.5") == 2.5
+    # True
+    assert ArgumentHandler._qualify_argument(bool, [], "True") is True
+    assert ArgumentHandler._qualify_argument(bool, [], "1") is True
+    assert ArgumentHandler._qualify_argument(bool, [], 1) is True
+    assert ArgumentHandler._qualify_argument(bool, [], "anything") is True
+    # False
+    assert ArgumentHandler._qualify_argument(bool, [], "") is False
+    assert ArgumentHandler._qualify_argument(bool, [], None) is False
+    for val in ["FALSE", "False", "false", "0", 0, "NO", "No", "no"]:
+        assert ArgumentHandler._qualify_argument(bool, [], val) is False
+    # list
+    assert ArgumentHandler._qualify_argument(list, [], "abcd") == ["a", "b", "c", "d"]
+    assert ArgumentHandler._qualify_argument(list, [], "") == []
+
+    # Test Choices:
+    assert ArgumentHandler._qualify_argument(bool, [True], "anything") is True
+    assert ArgumentHandler._qualify_argument(int, [0, 1, 2], "1") == 1
+    assert ArgumentHandler._qualify_argument(None, [""], "") == ""
+    ArgumentHandler._qualify_argument(None, [23, "23"], "23")
 
 
-def test_type_check() -> None:
+def test_01_qualify_argument_errors() -> None:
+    """Test `_qualify_argument()`."""
+    # Test Types:
+    with pytest.raises(tornado.web.HTTPError) as e:
+        ArgumentHandler._qualify_argument(int, [], "")
+    assert "(ValueError)" in str(e.value)
+    with pytest.raises(tornado.web.HTTPError) as e:
+        ArgumentHandler._qualify_argument(float, [], "")
+    assert "(ValueError)" in str(e.value)
+    with pytest.raises(tornado.web.HTTPError) as e:
+        ArgumentHandler._qualify_argument(float, [], "123abc")
+    assert "(ValueError)" in str(e.value)
+
+    # Test Choices:
+    with pytest.raises(tornado.web.HTTPError) as e:
+        ArgumentHandler._qualify_argument(None, [23], "23")
+    assert "(ValueError)" in str(e.value) and "not in options" in str(e.value)
+    with pytest.raises(tornado.web.HTTPError) as e:
+        ArgumentHandler._qualify_argument(str, ["STRING"], "string")
+    assert "(ValueError)" in str(e.value) and "not in options" in str(e.value)
+    with pytest.raises(tornado.web.HTTPError) as e:
+        ArgumentHandler._qualify_argument(int, [0, 1, 2], "3")
+    assert "(ValueError)" in str(e.value) and "not in options" in str(e.value)
+    with pytest.raises(tornado.web.HTTPError) as e:
+        ArgumentHandler._qualify_argument(list, [["a", "b", "c", "d"]], "abc")
+    assert "(ValueError)" in str(e.value) and "not in options" in str(e.value)
+
+
+def test_10_type_check() -> None:
     """Test `_type_check()`."""
     pass
 
 
-def test_get_argument_no_body_00() -> None:
+def test_20_get_argument_no_body() -> None:
     """Test `request.arguments`/`RequestHandler.get_argument()` arguments.
 
     No tests for body-parsing.
@@ -19,7 +87,7 @@ def test_get_argument_no_body_00() -> None:
     pass
 
 
-def test_get_argument_no_body_01() -> None:
+def test_21_get_argument_no_body() -> None:
     """Test `request.arguments`/`RequestHandler.get_argument()` arguments.
 
     No tests for body-parsing.
@@ -27,21 +95,21 @@ def test_get_argument_no_body_01() -> None:
     pass
 
 
-def test_get_json_body_argument_00() -> None:
+def test_30_get_json_body_argument() -> None:
     """Test `request.body` JSON arguments."""
     pass
 
 
-def test_get_json_body_argument_01() -> None:
+def test_31_get_json_body_argument() -> None:
     """Test `request.body` JSON arguments."""
     pass
 
 
-def test_get_argument_args_and_body_00() -> None:
+def test_40_get_argument_args_and_body() -> None:
     """Test `get_argument()`."""
     pass
 
 
-def test_get_argument_args_and_body_01() -> None:
+def test_41_get_argument_args_and_body() -> None:
     """Test `get_argument()`."""
     pass

--- a/tests/server/arghandler_test.py
+++ b/tests/server/arghandler_test.py
@@ -128,34 +128,16 @@ def test_30_get_json_body_argument(gjb: Mock) -> None:
     # Simple Use Cases
     for arg, val in body.items():
         gjb.return_value = body
-        ret = ArgumentHandler.get_json_body_argument(ANY, arg, None, False, None, [])
+        ret = ArgumentHandler.get_json_body_argument(ANY, arg, None, [])
         assert ret == val
 
     # Default Use Cases
     for arg, val in body.items():
         gjb.return_value = {a: v for a, v in body.items() if a != arg}
-        ret = ArgumentHandler.get_json_body_argument(ANY, arg, "Terry", False, None, [])
+        ret = ArgumentHandler.get_json_body_argument(ANY, arg, "Terry", [])
         assert ret == "Terry"
 
-    def pad(val: Any) -> Any:
-        if isinstance(val, str):
-            return f" \t {val} \n  "
-        return val
-
-    # Strip Use Cases
-    for arg, val in body.items():
-        # w/ stripping
-        gjb.return_value = {a: pad(v) for a, v in body.items()}
-        ret = ArgumentHandler.get_json_body_argument(ANY, arg, None, True, None, [])
-        assert ret == val
-        # w/o stripping
-        gjb.return_value = {a: pad(v) for a, v in body.items()}
-        ret = ArgumentHandler.get_json_body_argument(ANY, arg, None, False, None, [])
-        assert ret == pad(val)
-        if isinstance(val, str):
-            assert ret != val
-
-    # NOTE - `type_` and `choices` are tested `_qualify_argument` tests
+    # NOTE - `choices` use-cases are tested `_qualify_argument` tests
 
 
 @patch("rest_tools.server.arghandler._get_json_body")
@@ -163,15 +145,10 @@ def test_31_get_json_body_argument_errors(gjb: Mock) -> None:
     """Test `request.body` JSON arguments."""
     body = {"green": 10, "eggs": True, "and": "wait for it...", "ham": [1, 2, 4]}
 
-    # Bad Default Type
-    with pytest.raises(ValueError):
-        gjb.return_value = body
-        ArgumentHandler.get_json_body_argument(ANY, "Name", 55, False, str, [])
-
     # Missing Required Argument
     with pytest.raises(tornado.web.MissingArgumentError) as e:
         gjb.return_value = body
-        ArgumentHandler.get_json_body_argument(ANY, "Reqd", NO_DEFAULT, False, None, [])
+        ArgumentHandler.get_json_body_argument(ANY, "Reqd", NO_DEFAULT, [])
     assert "Reqd" in str(e.value)
 
 

--- a/tests/server/arghandler_test.py
+++ b/tests/server/arghandler_test.py
@@ -122,9 +122,9 @@ def test_10_type_check() -> None:
                 ArgumentHandler._type_check(o_type, val)
 
 
-@patch("rest_tools.server.arghandler._get_json_body")
+@patch("rest_tools.server.arghandler._get_json_body_arguments")
 @patch("tornado.web.RequestHandler")
-def test_20_get_argument_no_body(twrh: Mock, gjb: Mock) -> None:
+def test_20_get_argument_no_body(twrh: Mock, gjba: Mock) -> None:
     """Test `request.arguments`/`RequestHandler.get_argument()` arguments.
 
     No tests for body-parsing.
@@ -143,12 +143,12 @@ def test_20_get_argument_no_body(twrh: Mock, gjb: Mock) -> None:
         print(val)
         print(type_)
         # w/o typing
-        gjb.return_value = {}
+        gjba.return_value = {}
         twrh.get_argument.return_value = val
         ret = ArgumentHandler.get_argument(twrh, arg, None, False, None, [])
         assert ret == val
         # w/ typing
-        gjb.return_value = {}
+        gjba.return_value = {}
         twrh.get_argument.return_value = val
         ret = ArgumentHandler.get_argument(twrh, arg, None, False, type_, [])
         assert ret == type_(val) or (val == "False" and ret is False and type_ == bool)
@@ -158,16 +158,16 @@ def test_20_get_argument_no_body(twrh: Mock, gjb: Mock) -> None:
     # NOTE - `choices` use-cases are tested in `_qualify_argument` tests
 
 
-@patch("rest_tools.server.arghandler._get_json_body")
+@patch("rest_tools.server.arghandler._get_json_body_arguments")
 @patch("tornado.web.RequestHandler")
-def test_21_get_argument_no_body_errors(twrh: Mock, gjb: Mock) -> None:
+def test_21_get_argument_no_body_errors(twrh: Mock, gjba: Mock) -> None:
     """Test `request.arguments`/`RequestHandler.get_argument()` arguments.
 
     No tests for body-parsing.
     """
     # Missing Required Argument
     with pytest.raises(tornado.web.HTTPError) as e:
-        gjb.return_value = {}
+        gjba.return_value = {}
         twrh.get_argument.side_effect = tornado.web.MissingArgumentError("Reqd")
         ArgumentHandler.get_argument(twrh, "Reqd", NO_DEFAULT, False, None, [])
     assert "Reqd" in str(e.value)
@@ -176,130 +176,130 @@ def test_21_get_argument_no_body_errors(twrh: Mock, gjb: Mock) -> None:
     # NOTE - `type_` and `choices` are tested in `_qualify_argument` tests
 
 
-@patch("rest_tools.server.arghandler._get_json_body")
-def test_30_get_json_body_argument(gjb: Mock) -> None:
+@patch("rest_tools.server.arghandler._get_json_body_arguments")
+def test_30_get_json_body_arguments_argument(gjba: Mock) -> None:
     """Test `request.body` JSON arguments."""
     body = {"green": 10, "eggs": True, "and": "wait for it...", "ham": [1, 2, 4]}
 
     # Simple Use Cases
     for arg, val in body.items():
-        gjb.return_value = body
+        gjba.return_value = body
         ret = ArgumentHandler.get_json_body_argument(ANY, arg, None, [])
         assert ret == val
 
     # Default Use Cases
     for arg, val in body.items():
-        gjb.return_value = {a: v for a, v in body.items() if a != arg}
+        gjba.return_value = {a: v for a, v in body.items() if a != arg}
         ret = ArgumentHandler.get_json_body_argument(ANY, arg, "Terry", [])
         assert ret == "Terry"
 
     # NOTE - `choices` use-cases are tested in `_qualify_argument` tests
 
 
-@patch("rest_tools.server.arghandler._get_json_body")
-def test_31_get_json_body_argument_errors(gjb: Mock) -> None:
+@patch("rest_tools.server.arghandler._get_json_body_arguments")
+def test_31_get_json_body_arguments_argument_errors(gjba: Mock) -> None:
     """Test `request.body` JSON arguments."""
     body = {"green": 10, "eggs": True, "and": "wait for it...", "ham": [1, 2, 4]}
 
     # Missing Required Argument
     with pytest.raises(tornado.web.MissingArgumentError) as e:
-        gjb.return_value = body
+        gjba.return_value = body
         ArgumentHandler.get_json_body_argument(ANY, "Reqd", NO_DEFAULT, [])
     assert "Reqd" in str(e.value)
 
     # NOTE - `choices` use-cases are tested in `_qualify_argument` tests
 
 
-@patch("rest_tools.server.arghandler._get_json_body")
+@patch("rest_tools.server.arghandler._get_json_body_arguments")
 @patch("tornado.web.RequestHandler")
-def test_40_get_argument_args_and_body(twrh: Mock, gjb: Mock) -> None:
+def test_40_get_argument_args_and_body(twrh: Mock, gjba: Mock) -> None:
     """Test `get_argument()`.
 
     From JSON-body (no Query-Args)
     """
     # TODO - patch based on argument: https://stackoverflow.com/a/16162316/13156561
-    gjb.return_value = {"foo": 14}
+    gjba.return_value = {"foo": 14}
 
     ret = ArgumentHandler.get_argument(twrh, "foo", None, False, None, [])
 
-    gjb.assert_called_with(twrh)
+    gjba.assert_called_with(twrh)
     twrh.get_argument.assert_not_called()
     assert ret == 14
 
 
-@patch("rest_tools.server.arghandler._get_json_body")
+@patch("rest_tools.server.arghandler._get_json_body_arguments")
 @patch("tornado.web.RequestHandler")
-def test_41_get_argument_args_and_body(twrh: Mock, gjb: Mock) -> None:
+def test_41_get_argument_args_and_body(twrh: Mock, gjba: Mock) -> None:
     """Test `get_argument()`.
 
     From Query-Args (no JSON-body arguments)
     """
-    gjb.return_value = {}
+    gjba.return_value = {}
     twrh.get_argument.return_value = 55
 
     ret = ArgumentHandler.get_argument(twrh, "foo", None, False, None, [])
 
-    gjb.assert_called_with(twrh)
+    gjba.assert_called_with(twrh)
     twrh.get_argument.assert_called_with("foo", None, strip=False)
     assert ret == 55
 
 
-@patch("rest_tools.server.arghandler._get_json_body")
+@patch("rest_tools.server.arghandler._get_json_body_arguments")
 @patch("tornado.web.RequestHandler")
-def test_42_get_argument_args_and_body(twrh: Mock, gjb: Mock) -> None:
+def test_42_get_argument_args_and_body(twrh: Mock, gjba: Mock) -> None:
     """Test `get_argument()`.
 
     From Query-Args (with JSON & Query-Arg values) -- but only 1 match
     """
-    gjb.return_value = {"baz": 7}
+    gjba.return_value = {"baz": 7}
     twrh.get_argument.return_value = 90
 
     ret = ArgumentHandler.get_argument(twrh, "foo", None, False, None, [])
 
-    gjb.assert_called_with(twrh)
+    gjba.assert_called_with(twrh)
     twrh.get_argument.assert_called_with("foo", None, strip=False)
     assert ret == 90
 
 
-@patch("rest_tools.server.arghandler._get_json_body")
+@patch("rest_tools.server.arghandler._get_json_body_arguments")
 @patch("tornado.web.RequestHandler")
-def test_43_get_argument_args_and_body(twrh: Mock, gjb: Mock) -> None:
+def test_43_get_argument_args_and_body(twrh: Mock, gjba: Mock) -> None:
     """Test `get_argument()`.
 
     From JSON-body (with JSON & Query-Arg matches) -> should grab JSON
     """
-    gjb.return_value = {"foo": 1}
+    gjba.return_value = {"foo": 1}
     twrh.get_argument.return_value = -8
 
     ret = ArgumentHandler.get_argument(twrh, "foo", None, False, None, [])
 
-    gjb.assert_called_with(twrh)
+    gjba.assert_called_with(twrh)
     twrh.get_argument.assert_not_called()
     assert ret == 1
 
 
-@patch("rest_tools.server.arghandler._get_json_body")
+@patch("rest_tools.server.arghandler._get_json_body_arguments")
 @patch("tornado.web.RequestHandler")
-def test_44_get_argument_args_and_body(twrh: Mock, gjb: Mock) -> None:
+def test_44_get_argument_args_and_body(twrh: Mock, gjba: Mock) -> None:
     """Test `get_argument()`.
 
     From JSON-body (with JSON & Query-Arg matches) -> should grab JSON
 
     **Test JSON-body arg typing**
     """
-    gjb.return_value = {"foo": "99"}
+    gjba.return_value = {"foo": "99"}
     twrh.get_argument.return_value = -0.5
 
     ret = ArgumentHandler.get_argument(twrh, "foo", None, False, int, [])
 
-    gjb.assert_called_with(twrh)
+    gjba.assert_called_with(twrh)
     twrh.get_argument.assert_not_called()
     assert ret == 99
 
 
-@patch("rest_tools.server.arghandler._get_json_body")
+@patch("rest_tools.server.arghandler._get_json_body_arguments")
 @patch("tornado.web.RequestHandler")
-def test_45_get_argument_args_and_body_errors(twrh: Mock, gjb: Mock) -> None:
+def test_45_get_argument_args_and_body_errors(twrh: Mock, gjba: Mock) -> None:
     """Test `get_argument()`.
 
     **Error-Test JSON-body arg typing**
@@ -307,7 +307,7 @@ def test_45_get_argument_args_and_body_errors(twrh: Mock, gjb: Mock) -> None:
     If there's a matching argument in JSON-body, but it's the wrong type, raise 400;
     REGARDLESS if there's a value in the Query-Args.
     """
-    gjb.return_value = {"foo": "NINETY-NINE"}
+    gjba.return_value = {"foo": "NINETY-NINE"}
     twrh.get_argument.return_value = -0.5
 
     with pytest.raises(tornado.web.HTTPError) as e:
@@ -317,13 +317,13 @@ def test_45_get_argument_args_and_body_errors(twrh: Mock, gjb: Mock) -> None:
     assert "NINETY-NINE" in str(e.value)
     assert "foo" in str(e.value)
 
-    gjb.assert_called_with(twrh)
+    gjba.assert_called_with(twrh)
     twrh.get_argument.assert_not_called()
 
 
-@patch("rest_tools.server.arghandler._get_json_body")
+@patch("rest_tools.server.arghandler._get_json_body_arguments")
 @patch("tornado.web.RequestHandler")
-def test_46_get_argument_args_and_body_errors(twrh: Mock, gjb: Mock) -> None:
+def test_46_get_argument_args_and_body_errors(twrh: Mock, gjba: Mock) -> None:
     """Test `get_argument()`.
 
     **Error-Test JSON-body arg choices**
@@ -331,7 +331,7 @@ def test_46_get_argument_args_and_body_errors(twrh: Mock, gjb: Mock) -> None:
     If there's a matching argument in JSON-body, but it's not in choices, raise 400;
     REGARDLESS if there's a value in the Query-Args.
     """
-    gjb.return_value = {"foo": 5}
+    gjba.return_value = {"foo": 5}
     twrh.get_argument.return_value = 0
 
     with pytest.raises(tornado.web.HTTPError) as e:
@@ -340,5 +340,5 @@ def test_46_get_argument_args_and_body_errors(twrh: Mock, gjb: Mock) -> None:
     assert "400" in str(e.value)
     assert "foo" in str(e.value)
 
-    gjb.assert_called_with(twrh)
+    gjba.assert_called_with(twrh)
     twrh.get_argument.assert_not_called()

--- a/tests/server/arghandler_test.py
+++ b/tests/server/arghandler_test.py
@@ -32,21 +32,33 @@ def test_00_qualify_argument() -> None:
     # float
     assert ArgumentHandler._qualify_argument(float, [], "2.5") == 2.5
     # True
-    assert ArgumentHandler._qualify_argument(bool, [], "True") is True
     assert ArgumentHandler._qualify_argument(bool, [], "1") is True
     assert ArgumentHandler._qualify_argument(bool, [], 1) is True
-    assert ArgumentHandler._qualify_argument(bool, [], "anything") is True
+    assert ArgumentHandler._qualify_argument(bool, [], -99) is True
+    for trues in ["True", "T", "On", "Yes", "Y"]:
+        for val in [
+            trues.upper(),
+            trues.lower(),
+            trues[:-1] + trues[-1].upper(),  # upper only last char
+        ]:
+            assert ArgumentHandler._qualify_argument(bool, [], val) is True
     # False
     assert ArgumentHandler._qualify_argument(bool, [], "") is False
-    assert ArgumentHandler._qualify_argument(bool, [], None) is False
-    for val in ["FALSE", "False", "false", "0", 0, "NO", "No", "no"]:
-        assert ArgumentHandler._qualify_argument(bool, [], val) is False
+    assert ArgumentHandler._qualify_argument(bool, [], "0") is False
+    assert ArgumentHandler._qualify_argument(bool, [], 0) is False
+    for falses in ["False", "F", "Off", "No", "N"]:
+        for val in [
+            falses.upper(),
+            falses.lower(),
+            falses[:-1] + falses[-1].upper(),  # upper only last char
+        ]:
+            assert ArgumentHandler._qualify_argument(bool, [], val) is False
     # list
     assert ArgumentHandler._qualify_argument(list, [], "abcd") == ["a", "b", "c", "d"]
     assert ArgumentHandler._qualify_argument(list, [], "") == []
 
     # Test Choices:
-    assert ArgumentHandler._qualify_argument(bool, [True], "anything") is True
+    assert ArgumentHandler._qualify_argument(bool, [True, False], "t") is True
     assert ArgumentHandler._qualify_argument(int, [0, 1, 2], "1") == 1
     assert ArgumentHandler._qualify_argument(None, [""], "") == ""
     ArgumentHandler._qualify_argument(None, [23, "23"], "23")
@@ -63,6 +75,9 @@ def test_01_qualify_argument_errors() -> None:
     assert "(ValueError)" in str(e.value)
     with pytest.raises(_UnqualifiedArgumentError) as e:
         ArgumentHandler._qualify_argument(float, [], "123abc")
+    assert "(ValueError)" in str(e.value)
+    with pytest.raises(_UnqualifiedArgumentError) as e:
+        ArgumentHandler._qualify_argument(bool, [], "anything")
     assert "(ValueError)" in str(e.value)
 
     # Test Choices:

--- a/tests/server/arghandler_test.py
+++ b/tests/server/arghandler_test.py
@@ -76,7 +76,29 @@ def test_01_qualify_argument_errors() -> None:
 
 def test_10_type_check() -> None:
     """Test `_type_check()`."""
-    pass
+    vals = [
+        "abcdef",
+        1,
+        None,
+        ["this is", "a list"],
+        "",
+        2.5,
+        {"but this": "is a dict"},
+    ]
+
+    for val in vals:
+        print(val)
+        # Passing Cases
+        ArgumentHandler._type_check(type(val), val)
+        ArgumentHandler._type_check(None, val)  # type_ == None is always allowed
+
+        # Error Cases # pylint: disable=C0123
+        if val is None:  # val == None is always allowed
+            continue
+        for o_type in [type(o) for o in vals if type(o) != type(val)]:
+            print(o_type)
+            with pytest.raises(ValueError):
+                ArgumentHandler._type_check(o_type, val)
 
 
 def test_20_get_argument_no_body() -> None:


### PR DESCRIPTION
Wrap `json_decode(self.request.body)` and ~`get_query_argument()`~ `get_argument()`, with a default value, or a 400 error.