### PR TITLE
ArgumentHandler: Add Type-Checking for Body Arguments + Forbiddens List

### DIFF
--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -43,7 +43,7 @@ class ArgumentHandler:
     """
 
     @staticmethod
-    def _cast_type(type_: Optional[type], value: Any) -> Any:
+    def _cast_type(value: Any, type_: Optional[type]) -> Any:
         """Cast `value` to `cast_type` type.
 
         Raise _InvalidArgumentError if qualification fails.
@@ -62,7 +62,7 @@ class ArgumentHandler:
         return value
 
     @staticmethod
-    def _validate_choice(choices: Optional[List[Any]], value: Any) -> Any:
+    def _validate_choice(value: Any, choices: Optional[List[Any]]) -> Any:
         """Check that `value` is in `choices`.
 
         Raise _InvalidArgumentError if qualification fails.
@@ -79,8 +79,8 @@ class ArgumentHandler:
 
     @staticmethod
     def _check_type(
-        type_: Optional[type],
         value: Any,
+        type_: Optional[type],
         none_is_ok: bool = False,
         server_side_error: bool = False,
     ) -> Any:
@@ -121,8 +121,8 @@ class ArgumentHandler:
         """Get argument from the JSON-decoded request-body."""
         try:  # first, assume arg is required
             value = _parse_json_body_arguments(request_body)[name]
-            value = ArgumentHandler._validate_choice(choices, value)
-            value = ArgumentHandler._check_type(type_, value)
+            value = ArgumentHandler._validate_choice(value, choices)
+            value = ArgumentHandler._check_type(value, type_)
             return value
         except (KeyError, json.decoder.JSONDecodeError):
             # Required -> raise 400
@@ -133,8 +133,8 @@ class ArgumentHandler:
 
         # Else: Optional (aka use default value)
         try:
-            value = ArgumentHandler._validate_choice(choices, default)
-            value = ArgumentHandler._check_type(type_, value)
+            value = ArgumentHandler._validate_choice(default, choices)
+            value = ArgumentHandler._check_type(value, type_)
             return value
         except _InvalidArgumentError as e:
             raise _make_400_error(name, e)
@@ -168,8 +168,8 @@ class ArgumentHandler:
             # check query/base and body arguments
             try:
                 value = rest_handler_get_argument(name, strip=strip)
-                value = ArgumentHandler._cast_type(type_, value)
-                value = ArgumentHandler._validate_choice(choices, value)
+                value = ArgumentHandler._cast_type(value, type_)
+                value = ArgumentHandler._validate_choice(value, choices)
                 return value
             except (tornado.web.MissingArgumentError, _InvalidArgumentError) as e:
                 raise _make_400_error(name, e)
@@ -190,8 +190,8 @@ class ArgumentHandler:
         # check query base-arguments
         value = rest_handler_get_argument(name, default, strip=strip)
         try:
-            value = ArgumentHandler._cast_type(type_, value)
-            value = ArgumentHandler._validate_choice(choices, value)
+            value = ArgumentHandler._cast_type(value, type_,)
+            value = ArgumentHandler._validate_choice(value, choices)
             return value
         except _InvalidArgumentError as e:
             raise _make_400_error(name, e)

--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -72,7 +72,7 @@ class ArgumentHandler:
         value: Any,
         none_is_ok: bool = False,
         server_side_error: bool = False,
-    ) -> None:
+    ) -> Any:
         """Check the type of `value`.
 
         Keyword Arguments:
@@ -84,18 +84,20 @@ class ArgumentHandler:
             _UnqualifiedArgumentError -- if type check fails and `server_side_error=False`
         """
         if not type_:
-            return
+            return value
 
         if not isinstance(value, type_):
             # wait, is None okay?
             if value is None and none_is_ok:
-                return
+                return value
             # raise!
             msg = f"{value} ({type(value)}) is not {type_}{' or None' if none_is_ok else ''}"
             if server_side_error:
                 raise ValueError(msg)
             else:
                 raise _UnqualifiedArgumentError("(TypeError) " + msg)
+
+        return value
 
     @staticmethod
     def get_json_body_argument(  # pylint: disable=R0913

--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -78,7 +78,11 @@ class ArgumentHandler:
 
     @staticmethod
     def get_json_body_argument(  # pylint: disable=R0913
-        request_body: bytes, name: str, default: Any, choices: Optional[List[Any]],
+        request_body: bytes,
+        name: str,
+        default: Any,
+        type_: Optional[type],
+        choices: Optional[List[Any]],
     ) -> Any:
         """Return the argument from JSON-decoded request body."""
         try:

--- a/rest_tools/server/handler.py
+++ b/rest_tools/server/handler.py
@@ -147,6 +147,7 @@ class RestHandler(tornado.web.RequestHandler):
         default: Any = arghandler.NO_DEFAULT,
         type_: Optional[type] = None,
         choices: Optional[List[Any]] = None,
+        forbiddens: Optional[List[Any]] = None,
     ) -> Any:
         """Get argument from the JSON-decoded request-body.
 
@@ -159,12 +160,13 @@ class RestHandler(tornado.web.RequestHandler):
             default -- a default value to use if the argument is not present
             type_ -- optionally, type-check the argument's value (raise `400` for invalid value)
             choices -- a list of valid argument values (raise `400`, if arg's value is not in list)
+            forbiddens -- a list of disallowed argument values (raise `400`, if arg's value is in list)
 
         Returns:
             Any -- the argument's value, unaltered
         """
         return arghandler.ArgumentHandler.get_json_body_argument(
-            self.request.body, name, default, type_, choices
+            self.request.body, name, default, type_, choices, forbiddens
         )
 
     def get_argument(
@@ -174,6 +176,7 @@ class RestHandler(tornado.web.RequestHandler):
         strip: bool = True,
         type_: Optional[type] = None,
         choices: Optional[List[Any]] = None,
+        forbiddens: Optional[List[Any]] = None,
     ) -> Any:
         """Get argument from query base-arguments / JSON-decoded request-body.
 
@@ -187,12 +190,13 @@ class RestHandler(tornado.web.RequestHandler):
             strip {`bool`} -- whether to `str.strip()` the arg's value (default: {`True`})
             type_ -- optionally, type-cast/check the argument's value (raise `400` for invalid value)
             choices -- a list of valid argument values (raise `400`, if arg's value is not in list)
+            forbiddens -- a list of disallowed argument values (raise `400`, if arg's value is in list)
 
         Returns:
             Any -- the argument's value, possibly stripped/type-casted
         """
         return arghandler.ArgumentHandler.get_argument(
-            self.request.body, super().get_argument, name, default, strip, type_, choices
+            self.request.body, super().get_argument, name, default, strip, type_, choices, forbiddens
         )
 
 

--- a/rest_tools/server/handler.py
+++ b/rest_tools/server/handler.py
@@ -148,7 +148,7 @@ class RestHandler(tornado.web.RequestHandler):
         type_: Optional[type] = None,
         choices: Optional[List[Any]] = None,
     ) -> Any:
-        """Return the argument from JSON-decoded request body.
+        """Get argument from the JSON-decoded request-body.
 
         If no `default` is provided, and the argument is not present, raise `400`.
 
@@ -175,7 +175,7 @@ class RestHandler(tornado.web.RequestHandler):
         type_: Optional[type] = None,
         choices: Optional[List[Any]] = None,
     ) -> Any:
-        """Return argument from query arguments or JSON-decoded request body.
+        """Get argument from query base-arguments / JSON-decoded request-body.
 
         If no `default` is provided, and the argument is not present, raise `400`.
 

--- a/rest_tools/server/handler.py
+++ b/rest_tools/server/handler.py
@@ -145,7 +145,7 @@ class RestHandler(tornado.web.RequestHandler):
         self,
         name: str,
         default: Any = arghandler.NO_DEFAULT,
-        type_: Optional[type] = None,
+        type: Optional[type] = None,
         choices: Optional[List[Any]] = None,
         forbiddens: Optional[List[Any]] = None,
     ) -> Any:
@@ -158,7 +158,7 @@ class RestHandler(tornado.web.RequestHandler):
 
         Keyword Arguments:
             default -- a default value to use if the argument is not present
-            type_ -- optionally, type-check the argument's value (raise `400` for invalid value)
+            type -- optionally, type-check the argument's value (raise `400` for invalid value)
             choices -- a list of valid argument values (raise `400`, if arg's value is not in list)
             forbiddens -- a list of disallowed argument values (raise `400`, if arg's value is in list)
 
@@ -166,7 +166,7 @@ class RestHandler(tornado.web.RequestHandler):
             Any -- the argument's value, unaltered
         """
         return arghandler.ArgumentHandler.get_json_body_argument(
-            self.request.body, name, default, type_, choices, forbiddens
+            self.request.body, name, default, type, choices, forbiddens
         )
 
     def get_argument(
@@ -174,7 +174,7 @@ class RestHandler(tornado.web.RequestHandler):
         name: str,
         default: Any = arghandler.NO_DEFAULT,
         strip: bool = True,
-        type_: Optional[type] = None,
+        type: Optional[type] = None,
         choices: Optional[List[Any]] = None,
         forbiddens: Optional[List[Any]] = None,
     ) -> Any:
@@ -188,7 +188,7 @@ class RestHandler(tornado.web.RequestHandler):
         Keyword Arguments:
             default -- a default value to use if the argument is not present
             strip {`bool`} -- whether to `str.strip()` the arg's value (default: {`True`})
-            type_ -- optionally, type-cast/check the argument's value (raise `400` for invalid value)
+            type -- optionally, type-cast/check the argument's value (raise `400` for invalid value)
             choices -- a list of valid argument values (raise `400`, if arg's value is not in list)
             forbiddens -- a list of disallowed argument values (raise `400`, if arg's value is in list)
 
@@ -196,7 +196,7 @@ class RestHandler(tornado.web.RequestHandler):
             Any -- the argument's value, possibly stripped/type-casted
         """
         return arghandler.ArgumentHandler.get_argument(
-            self.request.body, super().get_argument, name, default, strip, type_, choices, forbiddens
+            self.request.body, super().get_argument, name, default, strip, type, choices, forbiddens
         )
 
 

--- a/rest_tools/server/handler.py
+++ b/rest_tools/server/handler.py
@@ -9,12 +9,10 @@ from collections import defaultdict
 from functools import partial, wraps
 from typing import Any, List, Optional
 
+import rest_tools
 import tornado.gen
 import tornado.httpclient
 import tornado.web
-
-# local imports
-import rest_tools
 
 from . import arghandler
 from .auth import Auth, OpenIDAuth
@@ -147,6 +145,7 @@ class RestHandler(tornado.web.RequestHandler):
         self,
         name: str,
         default: Any = arghandler.NO_DEFAULT,
+        type_: Optional[type] = None,
         choices: Optional[List[Any]] = None,
     ) -> Any:
         """Return the argument from JSON-decoded request body.
@@ -158,13 +157,14 @@ class RestHandler(tornado.web.RequestHandler):
 
         Keyword Arguments:
             default -- a default value to use if the argument is not present
+            type_ -- optionally, type-check the argument's value (raise `400` for invalid value)
             choices -- a list of valid argument values (raise `400`, if arg's value is not in list)
 
         Returns:
             Any -- the argument's value, unaltered
         """
         return arghandler.ArgumentHandler.get_json_body_argument(
-            self.request.body, name, default, choices
+            self.request.body, name, default, type_, choices
         )
 
     def get_argument(
@@ -185,7 +185,7 @@ class RestHandler(tornado.web.RequestHandler):
         Keyword Arguments:
             default -- a default value to use if the argument is not present
             strip {`bool`} -- whether to `str.strip()` the arg's value (default: {`True`})
-            type_ -- optionally, type-cast the argument's value (raise `400` on `TypeError`)
+            type_ -- optionally, type-cast/check the argument's value (raise `400` for invalid value)
             choices -- a list of valid argument values (raise `400`, if arg's value is not in list)
 
         Returns:

--- a/tests/server/arghandler_test.py
+++ b/tests/server/arghandler_test.py
@@ -141,7 +141,7 @@ def test_04_check_type() -> None:
         print(val)
         # Passing Cases:
         ArgumentHandler._check_type(val, type(val))
-        ArgumentHandler._check_type(val, None)  # type_=None is always allowed
+        ArgumentHandler._check_type(val, None)  # type=None is always allowed
         ArgumentHandler._check_type(None, type(val), none_is_ok=True)
 
         # Error Cases:
@@ -192,7 +192,7 @@ def test_20_get_argument_no_body(
         # w/ typing
         pjba.return_value = {}
         rhga.return_value = val
-        ret = rest_handler.get_argument(arg, default=None, type_=type_)
+        ret = rest_handler.get_argument(arg, default=None, type=type_)
         assert ret == type_(val) or (val == "False" and ret is False and type_ == bool)
 
     # NOTE - `default` non-error use-cases solely on RequestHandler.get_argument(), so no tests
@@ -268,7 +268,7 @@ def test_32_get_json_body_argument_typechecking(
     """
     pjba.return_value = {"foo": "99.9"}
 
-    ret = rest_handler.get_json_body_argument("foo", default=None, type_=str)
+    ret = rest_handler.get_json_body_argument("foo", default=None, type=str)
 
     pjba.assert_called()
     assert ret == "99.9"
@@ -277,7 +277,7 @@ def test_32_get_json_body_argument_typechecking(
 
     pjba.return_value = {"foo": ["a", "bc"]}
 
-    ret = rest_handler.get_json_body_argument("foo", default=None, type_=list)
+    ret = rest_handler.get_json_body_argument("foo", default=None, type=list)
 
     pjba.assert_called()
     assert ret == ["a", "bc"]
@@ -295,7 +295,7 @@ def test_33_get_json_body_argument_typechecking__errors(
     pjba.return_value = {"foo": "NINETY-NINE"}
 
     with pytest.raises(tornado.web.HTTPError) as e:
-        rest_handler.get_json_body_argument("foo", default=None, type_=float)
+        rest_handler.get_json_body_argument("foo", default=None, type=float)
     assert "(TypeError)" in str(e.value)
     assert "400" in str(e.value)
     assert "NINETY-NINE" in str(e.value)
@@ -309,7 +309,7 @@ def test_33_get_json_body_argument_typechecking__errors(
     pjba.return_value = {"baz": "I'm not a list"}
 
     with pytest.raises(tornado.web.HTTPError) as e:
-        rest_handler.get_json_body_argument("baz", default=None, type_=list)
+        rest_handler.get_json_body_argument("baz", default=None, type=list)
     assert "(TypeError)" in str(e.value)
     assert "400" in str(e.value)
     assert "I'm not a list" in str(e.value)
@@ -408,7 +408,7 @@ def test_44_get_argument_args_and_body(
     pjba.return_value = {"foo": "99.9"}
     rhga.return_value = -0.5
 
-    ret = rest_handler.get_argument("foo", default=None, type_=str)
+    ret = rest_handler.get_argument("foo", default=None, type=str)
 
     pjba.assert_called()
     rhga.assert_not_called()
@@ -419,7 +419,7 @@ def test_44_get_argument_args_and_body(
     pjba.return_value = {"foo": ["a", "bc"]}
     rhga.return_value = "1 2 3"
 
-    ret = rest_handler.get_argument("foo", default=None, type_=list)
+    ret = rest_handler.get_argument("foo", default=None, type=list)
 
     pjba.assert_called()
     rhga.assert_not_called()
@@ -442,7 +442,7 @@ def test_45_get_argument_args_and_body__errors(
     rhga.return_value = -0.5
 
     with pytest.raises(tornado.web.HTTPError) as e:
-        rest_handler.get_argument("foo", default=None, type_=float)
+        rest_handler.get_argument("foo", default=None, type=float)
     assert "(TypeError)" in str(e.value)
     assert "400" in str(e.value)
     assert "NINETY-NINE" in str(e.value)
@@ -458,7 +458,7 @@ def test_45_get_argument_args_and_body__errors(
     rhga.return_value = "me neither"
 
     with pytest.raises(tornado.web.HTTPError) as e:
-        rest_handler.get_argument("baz", default=None, type_=list)
+        rest_handler.get_argument("baz", default=None, type=list)
     assert "(TypeError)" in str(e.value)
     assert "400" in str(e.value)
     assert "I'm not a list" in str(e.value)

--- a/tests/server/arghandler_test.py
+++ b/tests/server/arghandler_test.py
@@ -19,82 +19,82 @@ def rest_handler() -> RestHandler:
 def test_00_cast_type() -> None:
     """Test `_cast_type()`."""
     # None - no casting
-    assert ArgumentHandler._cast_type(None, "string") == "string"
-    assert ArgumentHandler._cast_type(None, "0") == "0"
-    assert ArgumentHandler._cast_type(None, "2.5") == "2.5"
+    assert ArgumentHandler._cast_type("string", None) == "string"
+    assert ArgumentHandler._cast_type("0", None) == "0"
+    assert ArgumentHandler._cast_type("2.5", None) == "2.5"
     # str
-    assert ArgumentHandler._cast_type(str, "string") == "string"
-    assert ArgumentHandler._cast_type(str, "") == ""
-    assert ArgumentHandler._cast_type(str, 0) == "0"
+    assert ArgumentHandler._cast_type("string", str) == "string"
+    assert ArgumentHandler._cast_type("", str) == ""
+    assert ArgumentHandler._cast_type(0, str) == "0"
     # int
-    assert ArgumentHandler._cast_type(int, "1") == 1
-    assert ArgumentHandler._cast_type(int, "1") != "1"
+    assert ArgumentHandler._cast_type("1", int) == 1
+    assert ArgumentHandler._cast_type("1", int) != "1"
     # float
-    assert ArgumentHandler._cast_type(float, "2.5") == 2.5
+    assert ArgumentHandler._cast_type("2.5", float) == 2.5
     # True
-    assert ArgumentHandler._cast_type(bool, "1") is True
-    assert ArgumentHandler._cast_type(bool, 1) is True
-    assert ArgumentHandler._cast_type(bool, -99) is True
+    assert ArgumentHandler._cast_type("1", bool) is True
+    assert ArgumentHandler._cast_type(1, bool) is True
+    assert ArgumentHandler._cast_type(-99, bool) is True
     for trues in ["True", "T", "On", "Yes", "Y"]:
         for val in [
             trues.upper(),
             trues.lower(),
             trues[:-1] + trues[-1].upper(),  # upper only last char
         ]:
-            assert ArgumentHandler._cast_type(bool, val) is True
+            assert ArgumentHandler._cast_type(val, bool) is True
     # False
-    assert ArgumentHandler._cast_type(bool, "") is False
-    assert ArgumentHandler._cast_type(bool, "0") is False
-    assert ArgumentHandler._cast_type(bool, 0) is False
+    assert ArgumentHandler._cast_type("", bool) is False
+    assert ArgumentHandler._cast_type("0", bool) is False
+    assert ArgumentHandler._cast_type(0, bool) is False
     for falses in ["False", "F", "Off", "No", "N"]:
         for val in [
             falses.upper(),
             falses.lower(),
             falses[:-1] + falses[-1].upper(),  # upper only last char
         ]:
-            assert ArgumentHandler._cast_type(bool, val) is False
+            assert ArgumentHandler._cast_type(val, bool) is False
     # list
-    assert ArgumentHandler._cast_type(list, "abcd") == ["a", "b", "c", "d"]
-    assert ArgumentHandler._cast_type(list, "") == []
+    assert ArgumentHandler._cast_type("abcd", list) == ["a", "b", "c", "d"]
+    assert ArgumentHandler._cast_type("", list) == []
 
 
 def test_01_cast_type__errors() -> None:
     """Test `_cast_type()`."""
     with pytest.raises(_InvalidArgumentError) as e:
-        ArgumentHandler._cast_type(int, "")
+        ArgumentHandler._cast_type("", int)
     assert "(ValueError)" in str(e.value)
     with pytest.raises(_InvalidArgumentError) as e:
-        ArgumentHandler._cast_type(float, "")
+        ArgumentHandler._cast_type("", float)
     assert "(ValueError)" in str(e.value)
     with pytest.raises(_InvalidArgumentError) as e:
-        ArgumentHandler._cast_type(float, "123abc")
+        ArgumentHandler._cast_type("123abc", float)
     assert "(ValueError)" in str(e.value)
     with pytest.raises(_InvalidArgumentError) as e:
-        ArgumentHandler._cast_type(bool, "anything")
+        ArgumentHandler._cast_type("anything", bool)
     assert "(ValueError)" in str(e.value)
 
 
 def test_02_validate_choice() -> None:
     """Test `_validate_choice()`."""
-    assert ArgumentHandler._validate_choice([True, False], True) is True
-    assert ArgumentHandler._validate_choice([0, 1, 2], 1) == 1
-    assert ArgumentHandler._validate_choice([""], "") == ""
-    ArgumentHandler._validate_choice([23, "23"], "23")
+    assert ArgumentHandler._validate_choice(True, [True, False]) is True
+    assert ArgumentHandler._validate_choice(1, [0, 1, 2]) == 1
+    assert ArgumentHandler._validate_choice("", [""]) == ""
+    ArgumentHandler._validate_choice("23", [23, "23"])
 
 
 def test_03_validate_choice__errors() -> None:
     """Test `_validate_choice()`."""
     with pytest.raises(_InvalidArgumentError) as e:
-        ArgumentHandler._validate_choice([23], "23")
+        ArgumentHandler._validate_choice("23", [23])
     assert "(ValueError)" in str(e.value) and "not in choices" in str(e.value)
     with pytest.raises(_InvalidArgumentError) as e:
-        ArgumentHandler._validate_choice(["STRING"], "string")
+        ArgumentHandler._validate_choice("string", ["STRING"])
     assert "(ValueError)" in str(e.value) and "not in choices" in str(e.value)
     with pytest.raises(_InvalidArgumentError) as e:
-        ArgumentHandler._validate_choice([0, 1, 2], "3")
+        ArgumentHandler._validate_choice("3", [0, 1, 2])
     assert "(ValueError)" in str(e.value) and "not in choices" in str(e.value)
     with pytest.raises(_InvalidArgumentError) as e:
-        ArgumentHandler._validate_choice([["a", "b", "c", "d"]], "abc")
+        ArgumentHandler._validate_choice("abc", [["a", "b", "c", "d"]])
     assert "(ValueError)" in str(e.value) and "not in choices" in str(e.value)
 
 
@@ -113,26 +113,26 @@ def test_04_check_type() -> None:
     for val in vals:
         print(val)
         # Passing Cases:
-        ArgumentHandler._check_type(type(val), val)
-        ArgumentHandler._check_type(None, val)  # type_=None is always allowed
-        ArgumentHandler._check_type(type(val), None, none_is_ok=True)
+        ArgumentHandler._check_type(val, type(val))
+        ArgumentHandler._check_type(val, None)  # type_=None is always allowed
+        ArgumentHandler._check_type(None, type(val), none_is_ok=True)
 
         # Error Cases:
 
         # None is not allowed
         if val is not None:
             with pytest.raises(_InvalidArgumentError):
-                ArgumentHandler._check_type(type(val), None)
+                ArgumentHandler._check_type(None, type(val))
             with pytest.raises(ValueError):
-                ArgumentHandler._check_type(type(val), None, server_side_error=True)
+                ArgumentHandler._check_type(None, type(val), server_side_error=True)
 
         # type-mismatch  # pylint: disable=C0123
         for o_type in [type(o) for o in vals if type(o) != type(val)]:
             print(o_type)
             with pytest.raises(_InvalidArgumentError):
-                ArgumentHandler._check_type(o_type, val)
+                ArgumentHandler._check_type(val, o_type)
             with pytest.raises(ValueError):
-                ArgumentHandler._check_type(o_type, val, server_side_error=True)
+                ArgumentHandler._check_type(val, o_type, server_side_error=True)
 
 
 @patch("rest_tools.server.arghandler._parse_json_body_arguments")

--- a/tests/server/arghandler_test.py
+++ b/tests/server/arghandler_test.py
@@ -89,6 +89,7 @@ def test_02_validate_choice() -> None:
     ArgumentHandler._validate_choice("23", [23, "23"], [])
     ArgumentHandler._validate_choice("23", [23, "23"], ["boo!"])
     ArgumentHandler._validate_choice("23", ["23"], [23])
+    ArgumentHandler._validate_choice(["list"], None, [list(), dict()])
 
 
 def test_03_validate_choice__errors() -> None:
@@ -115,6 +116,12 @@ def test_03_validate_choice__errors() -> None:
     assert "(ValueError)" in str(e.value) and "is forbidden" in str(e.value)
     with pytest.raises(_InvalidArgumentError) as e:
         ArgumentHandler._validate_choice("baz", ["baz"], ["baz"])
+    assert "(ValueError)" in str(e.value) and "is forbidden" in str(e.value)
+    with pytest.raises(_InvalidArgumentError) as e:
+        ArgumentHandler._validate_choice([], None, [list(), dict()])
+    assert "(ValueError)" in str(e.value) and "is forbidden" in str(e.value)
+    with pytest.raises(_InvalidArgumentError) as e:
+        ArgumentHandler._validate_choice({}, None, [list(), dict()])
     assert "(ValueError)" in str(e.value) and "is forbidden" in str(e.value)
 
 


### PR DESCRIPTION
Updates:
- If `get_argument("body-arg-1", type_=list)` parses a body argument, and the argument is not a list (say `"mystr"`) it will raise a `400` error.
- `get_body_argument()` acts similarly via `type_` (optional).
- Added `forbiddens` optional list argument for explicitly excluding values (the opposite of `choices`) 

closes https://github.com/WIPACrepo/rest-tools/issues/12