### PR TITLE
Argument Handler No Default Error Message

### DIFF
--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -32,8 +32,10 @@ class _InvalidArgumentError(Exception):
 
 def _make_400_error(arg_name: str, error: Exception) -> tornado.web.HTTPError:
     if isinstance(error, tornado.web.MissingArgumentError):
-        return error  # MissingArgumentError is already a 400 error
-    return tornado.web.HTTPError(400, reason=f"`{arg_name}`: {error}")
+        reason = f"`{arg_name}`: (MissingArgumentError) required argument is missing"
+    else:
+        reason = f"`{arg_name}`: {error}"
+    return tornado.web.HTTPError(400, reason=reason)
 
 
 class ArgumentHandler:

--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -32,9 +32,10 @@ class _InvalidArgumentError(Exception):
 
 def _make_400_error(arg_name: str, error: Exception) -> tornado.web.HTTPError:
     if isinstance(error, tornado.web.MissingArgumentError):
-        error.log_message = (
+        error.reason = (
             f"`{arg_name}`: (MissingArgumentError) required argument is missing"
         )
+        error.log_message = ""
         return error
     else:
         return tornado.web.HTTPError(400, reason=f"`{arg_name}`: {error}")

--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -32,10 +32,12 @@ class _InvalidArgumentError(Exception):
 
 def _make_400_error(arg_name: str, error: Exception) -> tornado.web.HTTPError:
     if isinstance(error, tornado.web.MissingArgumentError):
-        reason = f"`{arg_name}`: (MissingArgumentError) required argument is missing"
+        error.log_message = (
+            f"`{arg_name}`: (MissingArgumentError) required argument is missing"
+        )
+        return error
     else:
-        reason = f"`{arg_name}`: {error}"
-    return tornado.web.HTTPError(400, reason=reason)
+        return tornado.web.HTTPError(400, reason=f"`{arg_name}`: {error}")
 
 
 class ArgumentHandler:

--- a/tests/server/arghandler_test.py
+++ b/tests/server/arghandler_test.py
@@ -214,8 +214,9 @@ def test_21_get_argument_no_body__errors(
         pjba.return_value = {}
         rhga.side_effect = tornado.web.MissingArgumentError("Reqd")
         rest_handler.get_argument("Reqd")
-    assert "Reqd" in str(e.value)
     assert "400" in str(e.value)
+    assert "Reqd" in str(e.value)
+    assert "(MissingArgumentError) required argument is missing" in str(e.value)
 
     # NOTE - `type_` and `choices` are tested in `_qualify_argument` tests
 
@@ -250,10 +251,12 @@ def test_31_get_json_body_argument__errors(
     body = {"green": 10, "eggs": True, "and": "wait for it...", "ham": [1, 2, 4]}
 
     # Missing Required Argument
-    with pytest.raises(tornado.web.MissingArgumentError) as e:
+    with pytest.raises(tornado.web.HTTPError) as e:
         pjba.return_value = body
         rest_handler.get_json_body_argument("Reqd")
+    assert "400" in str(e.value)
     assert "Reqd" in str(e.value)
+    assert "(MissingArgumentError) required argument is missing" in str(e.value)
 
     # NOTE - `choices` use-cases are tested in `_qualify_argument` tests
 

--- a/tests/server/arghandler_test.py
+++ b/tests/server/arghandler_test.py
@@ -214,9 +214,8 @@ def test_21_get_argument_no_body__errors(
         pjba.return_value = {}
         rhga.side_effect = tornado.web.MissingArgumentError("Reqd")
         rest_handler.get_argument("Reqd")
-    assert "400" in str(e.value)
-    assert "Reqd" in str(e.value)
-    assert "(MissingArgumentError) required argument is missing" in str(e.value)
+    error_msg = "HTTP 400: `Reqd`: (MissingArgumentError) required argument is missing"
+    assert str(e.value) == error_msg
 
     # NOTE - `type_` and `choices` are tested in `_qualify_argument` tests
 
@@ -254,9 +253,8 @@ def test_31_get_json_body_argument__errors(
     with pytest.raises(tornado.web.HTTPError) as e:
         pjba.return_value = body
         rest_handler.get_json_body_argument("Reqd")
-    assert "400" in str(e.value)
-    assert "Reqd" in str(e.value)
-    assert "(MissingArgumentError) required argument is missing" in str(e.value)
+    error_msg = "HTTP 400: `Reqd`: (MissingArgumentError) required argument is missing"
+    assert str(e.value) == error_msg
 
     # NOTE - `choices` use-cases are tested in `_qualify_argument` tests
 
@@ -299,10 +297,8 @@ def test_33_get_json_body_argument_typechecking__errors(
 
     with pytest.raises(tornado.web.HTTPError) as e:
         rest_handler.get_json_body_argument("foo", default=None, type=float)
-    assert "(TypeError)" in str(e.value)
-    assert "400" in str(e.value)
-    assert "NINETY-NINE" in str(e.value)
-    assert "foo" in str(e.value)
+    error_msg = "HTTP 400: `foo`: (TypeError) NINETY-NINE (<class 'str'>) is not <class 'float'>"
+    assert str(e.value) == error_msg
 
     pjba.assert_called()
 
@@ -313,10 +309,8 @@ def test_33_get_json_body_argument_typechecking__errors(
 
     with pytest.raises(tornado.web.HTTPError) as e:
         rest_handler.get_json_body_argument("baz", default=None, type=list)
-    assert "(TypeError)" in str(e.value)
-    assert "400" in str(e.value)
-    assert "I'm not a list" in str(e.value)
-    assert "baz" in str(e.value)
+    error_msg = "HTTP 400: `baz`: (TypeError) I'm not a list (<class 'str'>) is not <class 'list'>"
+    assert str(e.value) == error_msg
 
     pjba.assert_called()
 
@@ -446,10 +440,8 @@ def test_45_get_argument_args_and_body__errors(
 
     with pytest.raises(tornado.web.HTTPError) as e:
         rest_handler.get_argument("foo", default=None, type=float)
-    assert "(TypeError)" in str(e.value)
-    assert "400" in str(e.value)
-    assert "NINETY-NINE" in str(e.value)
-    assert "foo" in str(e.value)
+    error_msg = "HTTP 400: `foo`: (TypeError) NINETY-NINE (<class 'str'>) is not <class 'float'>"
+    assert str(e.value) == error_msg
 
     pjba.assert_called()
     rhga.assert_not_called()
@@ -462,10 +454,8 @@ def test_45_get_argument_args_and_body__errors(
 
     with pytest.raises(tornado.web.HTTPError) as e:
         rest_handler.get_argument("baz", default=None, type=list)
-    assert "(TypeError)" in str(e.value)
-    assert "400" in str(e.value)
-    assert "I'm not a list" in str(e.value)
-    assert "baz" in str(e.value)
+    error_msg = "HTTP 400: `baz`: (TypeError) I'm not a list (<class 'str'>) is not <class 'list'>"
+    assert str(e.value) == error_msg
 
     pjba.assert_called()
     rhga.assert_not_called()
@@ -489,9 +479,8 @@ def test_46_get_argument_args_and_body__errors(
 
     with pytest.raises(tornado.web.HTTPError) as e:
         rest_handler.get_argument("foo", default=None, choices=[0])
-    assert "(ValueError)" in str(e.value) and "not in choices" in str(e.value)
-    assert "400" in str(e.value)
-    assert "foo" in str(e.value)
+    error_msg = "HTTP 400: `foo`: (ValueError) 5 not in choices ([0])"
+    assert str(e.value) == error_msg
 
     pjba.assert_called()
     rhga.assert_not_called()
@@ -503,9 +492,8 @@ def test_46_get_argument_args_and_body__errors(
 
     with pytest.raises(tornado.web.HTTPError) as e:
         rest_handler.get_argument("foo", default=None, forbiddens=[5, 6, 7])
-    assert "(ValueError)" in str(e.value) and "is forbidden" in str(e.value)
-    assert "400" in str(e.value)
-    assert "foo" in str(e.value)
+    error_msg = "HTTP 400: `foo`: (ValueError) 5 is forbidden ([5, 6, 7])"
+    assert str(e.value) == error_msg
 
     pjba.assert_called()
     rhga.assert_not_called()


### PR DESCRIPTION
The 400 HTTP Error messages for missing arguments have been reformatted to match the other 400 error messages.

Before:
``` Bad Request (Missing argument <arg-name>) ```

Now:
``` `<arg-name>`: (MissingArgumentError) required argument is missing```

closes https://github.com/WIPACrepo/rest-tools/issues/14