### PR TITLE
NDJSON-Compliant Request Streaming

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,5 @@ requests-futures
 requests-mock
 requests_toolbelt
 sphinx
-sure==1.4.11
 tornado >= 5.0
 unidecode

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 coverage
 cryptography
+httpretty==1.0.5
 motor
 pycycle
 pyjwt >= 2.0.1
@@ -13,5 +14,6 @@ requests-futures
 requests-mock
 requests_toolbelt
 sphinx
+sure==1.4.11
 tornado >= 5.0
 unidecode

--- a/rest_tools/client/client.py
+++ b/rest_tools/client/client.py
@@ -219,7 +219,7 @@ class RestClient:
         """Send request to REST Server, and stream results back.
 
         `chunk_size=None` will read data as it arrives
-        in whatever size the chunks are received. `chunk_size`<`8`
+        in whatever size the chunks are received. `chunk_size`<`1`
         will be treated as `chunk_size=None`
 
         Args:
@@ -231,7 +231,7 @@ class RestClient:
         Returns:
             dict: json dict or raw string
         """
-        if chunk_size is not None and chunk_size < 8:
+        if chunk_size is not None and chunk_size < 1:
             chunk_size = None
 
         s = self.session

--- a/rest_tools/client/client.py
+++ b/rest_tools/client/client.py
@@ -219,7 +219,7 @@ class RestClient:
         """Send request to REST Server, and stream results back.
 
         `chunk_size=None` will read data as it arrives
-        in whatever size the chunks are received. `chunk_size`<`1`
+        in whatever size the chunks are received. `chunk_size`<`4`
         will be treated as `chunk_size=None`
 
         Args:
@@ -231,7 +231,7 @@ class RestClient:
         Returns:
             dict: json dict or raw string
         """
-        if chunk_size is not None and chunk_size < 1:
+        if chunk_size is not None and chunk_size < 4:
             chunk_size = None
 
         s = self.session

--- a/rest_tools/client/client.py
+++ b/rest_tools/client/client.py
@@ -100,6 +100,7 @@ class RestClient:
             # check if expired
             try:
                 # NOTE: PyJWT mis-type-hinted arg #1 as a str, but byte is also fine
+                # https://github.com/jpadilla/pyjwt/pull/605#issuecomment-772082918
                 data = jwt.decode(self.access_token, verify=False)  # type: ignore[arg-type]
                 if data['exp'] < time.time()+5:
                     raise Exception()

--- a/rest_tools/client/client.py
+++ b/rest_tools/client/client.py
@@ -219,7 +219,8 @@ class RestClient:
         """Send request to REST Server, and stream results back.
 
         `chunk_size=None` will read data as it arrives
-        in whatever size the chunks are received.
+        in whatever size the chunks are received. `chunk_size`<`1`
+        will be treated as `chunk_size=None`
 
         Args:
             method (str): the http method
@@ -230,6 +231,9 @@ class RestClient:
         Returns:
             dict: json dict or raw string
         """
+        if chunk_size is not None and chunk_size < 1:
+            chunk_size = None
+
         s = self.session
         try:
             self.open(sync=True)

--- a/rest_tools/client/client.py
+++ b/rest_tools/client/client.py
@@ -210,7 +210,7 @@ class RestClient:
         finally:
             self.session = s
 
-    async def request_stream(
+    def request_stream(
         self,
         method: str,
         path: str,

--- a/rest_tools/client/client.py
+++ b/rest_tools/client/client.py
@@ -23,7 +23,7 @@ from ..utils.json_util import JSONType, json_decode
 from .session import AsyncSession, Session, SessionType
 
 
-def to_str(s) -> str:
+def _to_str(s: Union[str, bytes]) -> str:
     if isinstance(s, bytes):
         return s.decode('utf-8')
     return s
@@ -136,7 +136,7 @@ class RestClient:
         if self.token_func:
             self._get_token()
         if self.access_token:
-            self.session.headers['Authorization'] = 'Bearer '+to_str(self.access_token)
+            self.session.headers['Authorization'] = 'Bearer ' + _to_str(self.access_token)
         return (url, kwargs)
 
     def _decode(self, content: Union[str, bytes, bytearray]) -> JSONType:
@@ -295,5 +295,5 @@ class OpenIDRestClient(RestClient):
     def _prepare(self, *args: Any, **kwargs: Any) -> Tuple[str, Dict[str, Any]]:
         self._get_token()
         if self.access_token:
-            self.session.headers['Authorization'] = 'Bearer '+to_str(self.access_token)
+            self.session.headers['Authorization'] = 'Bearer ' + _to_str(self.access_token)
         return super()._prepare(*args, **kwargs)

--- a/rest_tools/client/client.py
+++ b/rest_tools/client/client.py
@@ -219,7 +219,7 @@ class RestClient:
         """Send request to REST Server, and stream results back.
 
         `chunk_size=None` will read data as it arrives
-        in whatever size the chunks are received. `chunk_size`<`4`
+        in whatever size the chunks are received. `chunk_size`<`8`
         will be treated as `chunk_size=None`
 
         Args:
@@ -231,7 +231,7 @@ class RestClient:
         Returns:
             dict: json dict or raw string
         """
-        if chunk_size is not None and chunk_size < 4:
+        if chunk_size is not None and chunk_size < 8:
             chunk_size = None
 
         s = self.session

--- a/rest_tools/client/client.py
+++ b/rest_tools/client/client.py
@@ -226,7 +226,16 @@ class RestClient:
         Returns:
             dict: json dict or raw string
         """
-        pass
+        s = self.session
+        try:
+            self.open(sync=True)
+            url, kwargs = self._prepare(method, path, args)
+            resp = self.session.request(method, url, stream=True, **kwargs)
+            resp.raise_for_status()
+            for line in resp.iter_lines():
+                yield self._decode(line)
+        finally:
+            self.session = s
 
 
 class OpenIDRestClient(RestClient):

--- a/rest_tools/client/client.py
+++ b/rest_tools/client/client.py
@@ -207,6 +207,25 @@ class RestClient:
         finally:
             self.session = s
 
+    async def request_stream(
+        self,
+        method: str,
+        path: str,
+        args: Optional[Dict[str, Any]] = None
+    ) -> Generator[JSONType, None, None]:
+        """Send request to REST Server, and stream results back.
+
+        Args:
+            method (str): the http method
+            path (str): the url path on the server
+            args (dict): any arguments to pass
+
+        Returns:
+            dict: json dict or raw string
+        """
+        pass
+
+
 class OpenIDRestClient(RestClient):
     """A REST client that can handle token refresh using OpenID .well-known
     auto-discovery.

--- a/rest_tools/client/client.py
+++ b/rest_tools/client/client.py
@@ -240,8 +240,8 @@ class RestClient:
             url, kwargs = self._prepare(method, path, args)
             resp = self.session.request(method, url, stream=True, **kwargs)
             resp.raise_for_status()
-            for line in resp.iter_lines(chunk_size=chunk_size):
-                yield self._decode(line)
+            for line in resp.iter_lines(chunk_size=chunk_size, delimiter=b'\n'):
+                yield self._decode(line.strip())
         finally:
             self.session = s
 

--- a/rest_tools/client/client.py
+++ b/rest_tools/client/client.py
@@ -7,7 +7,6 @@ a json-encoded dictionary as necessary.
 """
 
 # fmt:off
-# pylint: skip-file
 
 import asyncio
 import logging

--- a/rest_tools/client/client.py
+++ b/rest_tools/client/client.py
@@ -53,8 +53,6 @@ class RestClient:
         self.timeout = timeout
         self.retries = retries
         self.kwargs = kwargs
-        self.session: Optional[SessionType] = None
-
         self.logger = logging.getLogger('RestClient')
         self.logger.setLevel('DEBUG')
 
@@ -67,9 +65,9 @@ class RestClient:
             elif callable(token):
                 self.token_func = token
 
-        self.open() # start session
+        self.session = self.open()  # start session
 
-    def open(self, sync: bool = False) -> None:
+    def open(self, sync: bool = False) -> SessionType:
         """Open the http session."""
         self.logger.info('establish REST http session')
         if sync:
@@ -88,6 +86,8 @@ class RestClient:
                 self.session.cert = self.kwargs['sslcert']
         if 'cacert' in self.kwargs:
             self.session.verify = self.kwargs['cacert']
+
+        return self.session
 
     def close(self) -> None:
         """Close the http session."""
@@ -108,7 +108,7 @@ class RestClient:
                 self.logger.debug('token expired')
 
         try:
-            self.access_token = self.token_func()
+            self.access_token = self.token_func()  # type: ignore[misc]
         except Exception:
             self.logger.warning('acquiring access token failed')
             raise

--- a/rest_tools/client/client.py
+++ b/rest_tools/client/client.py
@@ -214,14 +214,19 @@ class RestClient:
         self,
         method: str,
         path: str,
-        args: Optional[Dict[str, Any]] = None
+        args: Optional[Dict[str, Any]] = None,
+        chunk_size: Optional[int] = 8096
     ) -> Generator[JSONType, None, None]:
         """Send request to REST Server, and stream results back.
+
+        `chunk_size=None` will read data as it arrives
+        in whatever size the chunks are received.
 
         Args:
             method (str): the http method
             path (str): the url path on the server
             args (dict): any arguments to pass
+            chunk_size (int): chunk size (see above)
 
         Returns:
             dict: json dict or raw string
@@ -232,7 +237,7 @@ class RestClient:
             url, kwargs = self._prepare(method, path, args)
             resp = self.session.request(method, url, stream=True, **kwargs)
             resp.raise_for_status()
-            for line in resp.iter_lines():
+            for line in resp.iter_lines(chunk_size=chunk_size):
                 yield self._decode(line)
         finally:
             self.session = s

--- a/rest_tools/client/client.py
+++ b/rest_tools/client/client.py
@@ -99,7 +99,8 @@ class RestClient:
         if self.access_token:
             # check if expired
             try:
-                data = jwt.decode(self.access_token, verify=False)
+                # NOTE: PyJWT mis-type-hinted arg #1 as a str, but byte is also fine
+                data = jwt.decode(self.access_token, verify=False)  # type: ignore[arg-type]
                 if data['exp'] < time.time()+5:
                     raise Exception()
                 return

--- a/rest_tools/client/client.py
+++ b/rest_tools/client/client.py
@@ -241,7 +241,8 @@ class RestClient:
             resp = self.session.request(method, url, stream=True, **kwargs)
             resp.raise_for_status()
             for line in resp.iter_lines(chunk_size=chunk_size, delimiter=b'\n'):
-                yield self._decode(line.strip())
+                if decoded := self._decode(line.strip()):
+                    yield decoded
         finally:
             self.session = s
 

--- a/rest_tools/client/session.py
+++ b/rest_tools/client/session.py
@@ -1,5 +1,4 @@
-"""
-Get a `requests`_ Session that fully retries errors.
+"""Get a `requests`_ Session that fully retries errors.
 
 .. _requests: http://docs.python-requests.org
 """
@@ -7,18 +6,23 @@ Get a `requests`_ Session that fully retries errors.
 # fmt:off
 # pylint: skip-file
 
+from typing import Iterable, Union
+
 import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 from requests_futures.sessions import FuturesSession  # type: ignore[import]
 
+SessionType = Union[FuturesSession, requests.Session]
 
-def AsyncSession(retries=10, backoff_factor=0.3,
-            method_whitelist=('HEAD','TRACE','GET','POST','PUT','OPTIONS','DELETE'),
-            status_forcelist=(408, 429, 500, 502, 503, 504),
-            ):
-    """
-    Return a Session object with full retry capabilities.
+
+def AsyncSession(
+    retries: int = 10,
+    backoff_factor: float = 0.3,
+    method_whitelist: Iterable[str] = ('HEAD', 'TRACE', 'GET', 'POST', 'PUT', 'OPTIONS', 'DELETE'),
+    status_forcelist: Iterable[int] = (408, 429, 500, 502, 503, 504),
+) -> FuturesSession:
+    """Return a Session object with full retry capabilities.
 
     Args:
         retries (int): number of retries
@@ -45,12 +49,14 @@ def AsyncSession(retries=10, backoff_factor=0.3,
     session.mount('https://', adapter)
     return session
 
-def Session(retries=10, backoff_factor=0.3,
-            method_whitelist=('HEAD','TRACE','GET','POST','PUT','OPTIONS','DELETE'),
-            status_forcelist=(408, 429, 500, 502, 503, 504),
-            ):
-    """
-    Return a Session object with full retry capabilities.
+
+def Session(
+    retries: int = 10,
+    backoff_factor: float = 0.3,
+    method_whitelist: Iterable[str] = ('HEAD', 'TRACE', 'GET', 'POST', 'PUT', 'OPTIONS', 'DELETE'),
+    status_forcelist: Iterable[int] = (408, 429, 500, 502, 503, 504),
+) -> requests.Session:
+    """Return a Session object with full retry capabilities.
 
     Args:
         retries (int): number of retries

--- a/rest_tools/client/session.py
+++ b/rest_tools/client/session.py
@@ -13,8 +13,6 @@ from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 from requests_futures.sessions import FuturesSession  # type: ignore[import]
 
-SessionType = Union[FuturesSession, requests.Session]
-
 
 def AsyncSession(
     retries: int = 10,
@@ -39,7 +37,7 @@ def AsyncSession(
         connect=retries,
         read=retries,
         redirect=retries,
-        status=retries,
+        # status=retries,
         method_whitelist=method_whitelist,
         status_forcelist=status_forcelist,
         backoff_factor=backoff_factor,
@@ -73,7 +71,7 @@ def Session(
         connect=retries,
         read=retries,
         redirect=retries,
-        status=retries,
+        # status=retries,
         method_whitelist=method_whitelist,
         status_forcelist=status_forcelist,
         backoff_factor=backoff_factor,

--- a/rest_tools/utils/json_util.py
+++ b/rest_tools/utils/json_util.py
@@ -1,20 +1,27 @@
-"""
-Some JSON encoding and decoding utilities.
-"""
+"""Some JSON encoding and decoding utilities."""
 
-import json
-from datetime import date,datetime,time
+# fmt:off
+# pylint: skip-file
+
 import base64
-import zlib
+import json
 import logging
+import zlib
+from datetime import date, datetime, time
+from typing import Any, Optional, Union
 
 from tornado.escape import recursive_unicode
 
 logger = logging.getLogger('jsonUtil')
 
+
+JSONType = Any
+
+
 class json_compressor:
     """Used for files and other large things sent over json.
-       Great for log files.
+
+    Great for log files.
     """
     @staticmethod
     def compress(obj):
@@ -63,7 +70,8 @@ class time_converter(datetime_converter):
         return time(d.hour,d.minute,d.second,d.microsecond)
 
 class binary_converter:
-    """note that is is really only for decode of json, since python bytes are strings"""
+    """note that is is really only for decode of json, since python bytes are
+    strings."""
     @staticmethod
     def dumps(obj,name=None):
         return base64.b64encode(obj)
@@ -102,6 +110,7 @@ class var_converter:
 # for things like OrderedDict
 import ast
 from collections import OrderedDict
+
 
 class repr_converter:
     @staticmethod
@@ -157,10 +166,17 @@ def JSONToObj(obj):
     return ret
 
 
-def json_encode(value, indent=None):
+def json_encode(value: JSONType, indent: Optional[Union[int, str]] = None) -> str:
     """JSON-encodes the given Python object."""
-    return json.dumps(recursive_unicode(value),default=objToJSON,separators=(',',':'), indent=indent).replace("</", "<\\/")
+    string = json.dumps(
+        recursive_unicode(value),
+        default=objToJSON,
+        separators=(",", ":"),
+        indent=indent,
+    )
+    return string.replace("</", "<\\/")
 
-def json_decode(value):
-    """Returns Python objects for the given JSON string."""
-    return json.loads(value,object_hook=JSONToObj)
+
+def json_decode(value: Union[str, bytes, bytearray]) -> JSONType:
+    """Return Python objects for the given JSON string."""
+    return json.loads(value, object_hook=JSONToObj)

--- a/tests/client/client_test.py
+++ b/tests/client/client_test.py
@@ -237,6 +237,8 @@ def test_101_request_stream() -> None:
         [],
         [b"\n", b"\r\n", b"\n"],
         [b" \n"],
+        [b" "],
+        [b"\t"],
     ]
     for expected_stream in empty_streams:
         # test multiple times

--- a/tests/client/client_test.py
+++ b/tests/client/client_test.py
@@ -20,21 +20,16 @@ logger = logging.getLogger("rest_client")
 
 
 def test_01_init() -> None:
-    """Test init."""
-    address = "http://test"
-    auth_key = "passkey"
-    rpc = RestClient(address, auth_key)
+    """Test `__init__()` & `close()`."""
+    rpc = RestClient("http://test", "passkey")
     rpc.close()
 
 
 @pytest.mark.asyncio  # type: ignore[misc]
 async def test_10_request(requests_mock: Mock) -> None:
     """Test `async request()`."""
-    address = "http://test"
-    auth_key = "passkey"
     result = {"result": "the result"}
-
-    rpc = RestClient(address, auth_key, timeout=0.1)
+    rpc = RestClient("http://test", "passkey", timeout=0.1)
 
     def response(req: PreparedRequest, ctx: object) -> bytes:  # pylint: disable=W0613
         assert req.body is not None
@@ -64,11 +59,7 @@ async def test_10_request(requests_mock: Mock) -> None:
 @pytest.mark.asyncio  # type: ignore[misc]
 async def test_11_request(requests_mock: Mock) -> None:
     """Test request in `async request()`."""
-    address = "http://test"
-    auth_key = "passkey"
-    # result = ''
-
-    rpc = RestClient(address, auth_key, timeout=0.1)
+    rpc = RestClient("http://test", "passkey", timeout=0.1)
     requests_mock.get("/test", content=b"")
     ret = await rpc.request("GET", "test", {})
 
@@ -79,11 +70,7 @@ async def test_11_request(requests_mock: Mock) -> None:
 @pytest.mark.asyncio  # type: ignore[misc]
 async def test_20_timeout(requests_mock: Mock) -> None:
     """Test timeout in `async request()`."""
-    address = "http://test"
-    auth_key = "passkey"
-    # result = 'the result'
-
-    rpc = RestClient(address, auth_key, timeout=0.1, backoff=False)
+    rpc = RestClient("http://test", "passkey", timeout=0.1, backoff=False)
     requests_mock.post("/test", exc=Timeout)
 
     with pytest.raises(Timeout):
@@ -93,11 +80,7 @@ async def test_20_timeout(requests_mock: Mock) -> None:
 @pytest.mark.asyncio  # type: ignore[misc]
 async def test_21_ssl_error(requests_mock: Mock) -> None:
     """Test ssl error in `async request()`."""
-    address = "http://test"
-    auth_key = "passkey"
-    # result = 'the result'
-
-    rpc = RestClient(address, auth_key, timeout=0.1, backoff=False)
+    rpc = RestClient("http://test", "passkey", timeout=0.1, backoff=False)
     requests_mock.post("/test", exc=SSLError)
 
     with pytest.raises(SSLError):
@@ -107,11 +90,7 @@ async def test_21_ssl_error(requests_mock: Mock) -> None:
 @pytest.mark.asyncio  # type: ignore[misc]
 async def test_22_request(requests_mock: Mock) -> None:
     """Test `async request()`."""
-    address = "http://test"
-    auth_key = "passkey"
-    # result = ''
-
-    rpc = RestClient(address, auth_key, timeout=0.1)
+    rpc = RestClient("http://test", "passkey", timeout=0.1)
     requests_mock.get("/test", content=b'{"foo"}')
 
     with pytest.raises(Exception):
@@ -120,11 +99,8 @@ async def test_22_request(requests_mock: Mock) -> None:
 
 def test_90_request_seq(requests_mock: Mock) -> None:
     """Test `request_seq()`."""
-    address = "http://test"
-    auth_key = "passkey"
     result = {"result": "the result"}
-
-    rpc = RestClient(address, auth_key, timeout=0.1)
+    rpc = RestClient("http://test", "passkey", timeout=0.1)
 
     def response(req: PreparedRequest, ctx: object) -> bytes:  # pylint: disable=W0613
         assert req.body is not None
@@ -141,11 +117,8 @@ def test_90_request_seq(requests_mock: Mock) -> None:
 @pytest.mark.asyncio  # type: ignore[misc]
 async def test_91_request_seq(requests_mock: Mock) -> None:
     """Test `request_seq()`."""
-    address = "http://test"
-    auth_key = "passkey"
     result = {"result": "the result"}
-
-    rpc = RestClient(address, auth_key, timeout=0.1)
+    rpc = RestClient("http://test", "passkey", timeout=0.1)
 
     def response(req: PreparedRequest, ctx: object) -> bytes:  # pylint: disable=W0613
         assert req.body is not None
@@ -162,11 +135,7 @@ async def test_91_request_seq(requests_mock: Mock) -> None:
 @pytest.mark.asyncio  # type: ignore[misc]  # type: ignore[misc]
 async def test_92_request_seq(requests_mock: Mock) -> None:
     """Test `request_seq()`."""
-    address = "http://test"
-    auth_key = "passkey"
-    # result = {'result':'the result'}
-
-    rpc = RestClient(address, auth_key, timeout=0.1)
+    rpc = RestClient("http://test", "passkey", timeout=0.1)
 
     def response(req: PreparedRequest, ctx: object) -> bytes:  # pylint: disable=W0613
         raise Exception()

--- a/tests/client/client_test.py
+++ b/tests/client/client_test.py
@@ -10,7 +10,6 @@ from typing import Any
 from unittest.mock import Mock
 
 import pytest
-import requests  # TODO - remove
 from httpretty import HTTPretty, httprettified  # type: ignore[import]
 from requests import PreparedRequest
 from requests.exceptions import SSLError, Timeout

--- a/tests/client/client_test.py
+++ b/tests/client/client_test.py
@@ -176,9 +176,11 @@ def test_100_request_stream() -> None:
     mock_url = "http://test"
     expected_stream = [
         b'{"foo-bar":"baz"}\n',
+        b"\r\n",
         b"\n",
-        b'{"green":["eggs", "and", "ham"]}\n',
-        b'{"george": 1, "paul": 2, "ringo": 3, "john": 4}\n',
+        b'{"green":["eggs", "and", "ham"]}\r\n',
+        b'{"george": 1, "paul": 2, "ringo": 3, "john": 4}\r\n',
+        b"\n",
         b'"this is just a string"\n',
         b"[1,2,3]\n",
     ]
@@ -204,7 +206,7 @@ def test_100_request_stream() -> None:
                 assert resp == jsonify(expected_stream[i])
 
     # now w/ chunk sizes
-    for chunk_size in [None, 1, 0, -1, 8, 20, 100, 1024, 32768]:
+    for chunk_size in [None, 3, 0, -1, 4, 8, 20, 100, 1024, 32768]:
         print(f"\nchunk_size: {chunk_size}")
         HTTPretty.register_uri(
             HTTPretty.POST,

--- a/tests/client/client_test.py
+++ b/tests/client/client_test.py
@@ -2,12 +2,17 @@
 
 
 import logging
+import signal
 import sys
+from contextlib import contextmanager
 from unittest.mock import Mock
 
 import pytest
+import requests  # TODO - remove
+from httpretty import HTTPretty, httprettified  # type: ignore[import]
 from requests import PreparedRequest
 from requests.exceptions import SSLError, Timeout
+from sure import expect  # type: ignore[import]
 
 sys.path.append(".")
 from rest_tools.client import RestClient  # isort:skip # noqa # pylint: disable=C0413
@@ -146,18 +151,115 @@ async def test_92_request_seq(requests_mock: Mock) -> None:
         rpc.request_seq("POST", "test", {})
 
 
-def test_100_request_stream(requests_mock: Mock) -> None:
-    """Test `request_stream()`."""
-    result = {"result": "the result"}
-    rpc = RestClient("http://test", "passkey", timeout=0.1)
+@httprettified  # type: ignore[misc]
+def test_100_request_stream() -> None:
+    """Test `request_stream()`.
 
-    def response(req: PreparedRequest, ctx: object) -> bytes:  # pylint: disable=W0613
-        assert req.body is not None
-        _ = json_decode(req.body)
-        return json_encode(result).encode("utf-8")
+    Based on https://github.com/gabrielfalcao/HTTPretty/blob/master/tests/functional/test_requests.py#L290
+    """
 
-    requests_mock.post("/test", content=response)
-    ret = rpc.request_stream("POST", "test", {})
+    @contextmanager
+    def in_time(time, message):  # type: ignore[no-untyped-def]
+        # A context manager that uses signals to force a time limit in tests
+        # (unlike the `@within` decorator, which only complains afterward), or
+        # raise an AssertionError.
 
-    assert requests_mock.called
-    assert ret == result
+        def handler(signum, frame):  # type: ignore[no-untyped-def]
+            raise AssertionError(message)
+
+        signal.signal(signal.SIGALRM, handler)
+        signal.setitimer(signal.ITIMER_REAL, time)
+        yield
+        signal.setitimer(signal.ITIMER_REAL, 0)
+
+    # this obviously isn't a fully functional twitter streaming client!
+    twitter_response_lines = [
+        b'{"text":"If \\"for the boobs\\" requests to follow me one more time I\'m calling the police. http://t.co/a0mDEAD8"}\r\n',
+        b"\r\n",
+        b'{"text":"RT @onedirection: Thanks for all your # FollowMe1D requests Directioners! We\u2019ll be following 10 people throughout the day starting NOW. G ..."}\r\n',
+    ]
+
+    TWITTER_STREAMING_URL = "https://stream.twitter.com/1/statuses/filter.json"
+
+    HTTPretty.register_uri(
+        HTTPretty.POST,
+        TWITTER_STREAMING_URL,
+        body=(l for l in twitter_response_lines),
+        streaming=True,
+    )
+
+    # taken from the requests docs
+
+    # test iterating by line
+    # Http://docs.python-requests.org/en/latest/user/advanced/# streaming-requests
+    response = requests.post(
+        TWITTER_STREAMING_URL,
+        data={"track": "requests"},
+        auth=("username", "password"),
+        stream=True,
+    )
+
+    line_iter = response.iter_lines()
+    with in_time(0.01, "Iterating by line is taking forever!"):
+        for i in range(len(twitter_response_lines)):
+            expect(next(line_iter).strip()).to.equal(twitter_response_lines[i].strip())
+
+    HTTPretty.register_uri(
+        HTTPretty.POST,
+        TWITTER_STREAMING_URL,
+        body=(ln for ln in twitter_response_lines),
+        streaming=True,
+    )
+    # test iterating by line after a second request
+    response = requests.post(
+        TWITTER_STREAMING_URL,
+        data={"track": "requests"},
+        auth=("username", "password"),
+        stream=True,
+    )
+
+    line_iter = response.iter_lines()
+    with in_time(
+        0.01, "Iterating by line is taking forever the second time " "around!"
+    ):
+        for i in range(len(twitter_response_lines)):
+            expect(next(line_iter).strip()).to.equal(twitter_response_lines[i].strip())
+
+    HTTPretty.register_uri(
+        HTTPretty.POST,
+        TWITTER_STREAMING_URL,
+        body=(ln for ln in twitter_response_lines),
+        streaming=True,
+    )
+    # test iterating by char
+    response = requests.post(
+        TWITTER_STREAMING_URL,
+        data={"track": "requests"},
+        auth=("username", "password"),
+        stream=True,
+    )
+
+    twitter_expected_response_body = b"".join(twitter_response_lines)
+    with in_time(0.02, "Iterating by char is taking forever!"):
+        twitter_body = b"".join(c for c in response.iter_content(chunk_size=1))
+
+    expect(twitter_body).to.equal(twitter_expected_response_body)
+
+    # test iterating by chunks larger than the stream
+    HTTPretty.register_uri(
+        HTTPretty.POST,
+        TWITTER_STREAMING_URL,
+        body=(ln for ln in twitter_response_lines),
+        streaming=True,
+    )
+    response = requests.post(
+        TWITTER_STREAMING_URL,
+        data={"track": "requests"},
+        auth=("username", "password"),
+        stream=True,
+    )
+
+    with in_time(0.02, "Iterating by large chunks is taking forever!"):
+        twitter_body = b"".join(c for c in response.iter_content(chunk_size=1024))
+
+    expect(twitter_body).to.equal(twitter_expected_response_body)

--- a/tests/client/client_test.py
+++ b/tests/client/client_test.py
@@ -175,9 +175,9 @@ def test_100_request_stream() -> None:
     """
     mock_url = "http://test"
     expected_stream = [
-        b'{"foo-bar":"baz"}\r\n',
-        b"\r\n",
-        b'{"green":["eggs", "and", "ham"]}\r\n',
+        b'{"foo-bar":"baz"}\n',
+        b"\n",
+        b'{"green":["eggs", "and", "ham"]}\n',
         b'{"george": 1, "paul": 2, "ringo": 3, "john": 4}\n',
         b'"this is just a string"\n',
         b"[1,2,3]\n",
@@ -204,8 +204,7 @@ def test_100_request_stream() -> None:
                 assert resp == jsonify(expected_stream[i])
 
     # now w/ chunk sizes
-    # FIXME: chunk_size<8 fails for `\r\n` b/c it treats those as two separate lines
-    for chunk_size in [None, 8, 0, -1, 1024, 32768]:
+    for chunk_size in [None, 1, 0, -1, 8, 20, 100, 1024, 32768]:
         print(f"\nchunk_size: {chunk_size}")
         HTTPretty.register_uri(
             HTTPretty.POST,

--- a/tests/client/client_test.py
+++ b/tests/client/client_test.py
@@ -232,35 +232,45 @@ def test_101_request_stream() -> None:
     mock_url = "http://test"
     rpc = RestClient(mock_url, "passkey", timeout=1)
 
-    # test multiple times
-    for test_num in range(2):
-        print(f"\niteration #{test_num}")
-        HTTPretty.register_uri(
-            HTTPretty.POST, mock_url + "/stream/no-resp/", body=[b"\n"], streaming=True,
-        )
-        response_stream = rpc.request_stream("POST", "/stream/no-resp/", {})
+    empty_streams = [
+        [b"\n"],
+        [],
+        [b"\n", b"\r\n", b"\n"],
+        [b" \n"],
+    ]
+    for expected_stream in empty_streams:
+        # test multiple times
+        for test_num in range(2):
+            print(f"\niteration #{test_num}")
+            HTTPretty.register_uri(
+                HTTPretty.POST,
+                mock_url + "/stream/no-resp/",
+                body=expected_stream,
+                streaming=True,
+            )
+            response_stream = rpc.request_stream("POST", "/stream/no-resp/", {})
 
-        never_entered = True
-        with _in_time(0.01, "Iterating by line is taking forever!"):
-            for _ in response_stream:
-                never_entered = False
-        assert never_entered
+            never_entered = True
+            with _in_time(0.01, "Iterating by line is taking forever!"):
+                for _ in response_stream:
+                    never_entered = False
+            assert never_entered
 
-    # now w/ chunk sizes
-    for chunk_size in [None, 3, 0, -1, 4, 8, 9, 20, 100, 1024, 32768]:
-        print(f"\nchunk_size: {chunk_size}")
-        HTTPretty.register_uri(
-            HTTPretty.POST,
-            mock_url + "/stream/no-resp/w/chunks",
-            body=[b"\n"],
-            streaming=True,
-        )
-        response_stream = rpc.request_stream(
-            "POST", "/stream/no-resp/w/chunks", {}, chunk_size=chunk_size
-        )
+        # now w/ chunk sizes
+        for chunk_size in [None, 3, 0, -1, 4, 8, 9, 20, 100, 1024, 32768]:
+            print(f"\nchunk_size: {chunk_size}")
+            HTTPretty.register_uri(
+                HTTPretty.POST,
+                mock_url + "/stream/no-resp/w/chunks",
+                body=expected_stream,
+                streaming=True,
+            )
+            response_stream = rpc.request_stream(
+                "POST", "/stream/no-resp/w/chunks", {}, chunk_size=chunk_size
+            )
 
-        never_entered_w_chunks = True
-        with _in_time(0.01, "Iterating by line is taking forever w/ chunks!"):
-            for _ in response_stream:
-                never_entered_w_chunks = False
-        assert never_entered_w_chunks
+            never_entered_w_chunks = True
+            with _in_time(0.01, "Iterating by line is taking forever w/ chunks!"):
+                for _ in response_stream:
+                    never_entered_w_chunks = False
+            assert never_entered_w_chunks

--- a/tests/client/client_test.py
+++ b/tests/client/client_test.py
@@ -209,7 +209,7 @@ def test_100_request_stream() -> None:
                 assert resp == json_stream[i]
 
     # now w/ chunk sizes
-    for chunk_size in [None, 3, 0, -1, 4, 8, 9, 20, 100, 1024, 32768]:
+    for chunk_size in [None, -1, 0, 1, 2, 3, 4, 8, 9, 20, 100, 1024, 32768]:
         print(f"\nchunk_size: {chunk_size}")
         HTTPretty.register_uri(
             HTTPretty.POST,
@@ -260,7 +260,7 @@ def test_101_request_stream() -> None:
             assert never_entered
 
         # now w/ chunk sizes
-        for chunk_size in [None, 3, 0, -1, 4, 8, 9, 20, 100, 1024, 32768]:
+        for chunk_size in [None, -1, 0, 1, 2, 3, 4, 8, 9, 20, 100, 1024, 32768]:
             print(f"\nchunk_size: {chunk_size}")
             HTTPretty.register_uri(
                 HTTPretty.POST,
@@ -309,7 +309,7 @@ def test_102_request_stream() -> None:
                     assert resp == json_stream[i]
 
         # now w/ chunk sizes
-        for chunk_size in [None, 3, 0, -1, 4, 8, 9, 20, 100, 1024, 32768]:
+        for chunk_size in [None, -1, 0, 1, 2, 3, 4, 8, 9, 20, 100, 1024, 32768]:
             print(f"\nchunk_size: {chunk_size}")
             HTTPretty.register_uri(
                 HTTPretty.POST,

--- a/tests/client/client_test.py
+++ b/tests/client/client_test.py
@@ -174,7 +174,7 @@ def test_100_request_stream() -> None:
 
     Based on https://github.com/gabrielfalcao/HTTPretty/blob/master/tests/functional/test_requests.py#L290
     """
-    mock_url = "http://stream.test"
+    mock_url = "http://test"
     expected_stream = [
         b'{"foo-bar":"baz"}\r\n',
         b"\r\n",
@@ -193,11 +193,11 @@ def test_100_request_stream() -> None:
         print(f"\niteration #{test_num}")
         HTTPretty.register_uri(
             HTTPretty.POST,
-            mock_url + "/foo/bar/",
+            mock_url + "/stream/it/",
             body=(ln for ln in expected_stream),
             streaming=True,
         )
-        response_stream = rpc.request_stream("POST", "/foo/bar/", {})
+        response_stream = rpc.request_stream("POST", "/stream/it/", {})
 
         with _in_time(0.01, "Iterating by line is taking forever!"):
             for i, resp in enumerate(response_stream):
@@ -205,16 +205,17 @@ def test_100_request_stream() -> None:
                 assert resp == jsonify(expected_stream[i])
 
     # now w/ chunk sizes
+    # FIXME: chunk_size<8 fails for `\r\n` b/c it treats those as two separate lines
     for chunk_size in [None, 8, 0, -1, 1024, 32768]:
         print(f"\nchunk_size: {chunk_size}")
         HTTPretty.register_uri(
             HTTPretty.POST,
-            mock_url + "/foo/bar/",
+            mock_url + "/stream/it/w/chunks",
             body=(ln for ln in expected_stream),
             streaming=True,
         )
         response_stream = rpc.request_stream(
-            "POST", "/foo/bar/", {}, chunk_size=chunk_size
+            "POST", "/stream/it/w/chunks", {}, chunk_size=chunk_size
         )
 
         with _in_time(0.01, "Iterating by line is taking forever w/ chunks!"):

--- a/tests/client/client_test.py
+++ b/tests/client/client_test.py
@@ -1,7 +1,6 @@
 """Test script for RestClient."""
 
 # fmt:off
-# pylint: skip-file
 
 import logging
 import os
@@ -10,10 +9,8 @@ import tempfile
 import unittest
 
 import requests_mock  # type: ignore[import]
-from requests.exceptions import SSLError, Timeout
-
-# local imports
 import rest_tools.client
+from requests.exceptions import SSLError, Timeout
 
 logger = logging.getLogger('rest_client')
 
@@ -44,7 +41,7 @@ class rest_client_test(unittest.TestCase):
 
     @requests_mock.mock()
     async def test_10_request(self, mock):
-        """Test request."""
+        """Test `async request()`."""
         address = 'http://test'
         auth_key = 'passkey'
         result = {'result':'the result'}
@@ -75,7 +72,7 @@ class rest_client_test(unittest.TestCase):
 
     @requests_mock.mock()
     async def test_11_request(self, mock):
-        """Test request."""
+        """Test request in `async request()`."""
         address = 'http://test'
         auth_key = 'passkey'
         # result = ''
@@ -91,7 +88,7 @@ class rest_client_test(unittest.TestCase):
 
     @requests_mock.mock()
     async def test_20_timeout(self, mock):
-        """Test timeout."""
+        """Test timeout in `async request()`."""
         address = 'http://test'
         auth_key = 'passkey'
         # result = 'the result'
@@ -105,7 +102,7 @@ class rest_client_test(unittest.TestCase):
 
     @requests_mock.mock()
     async def test_21_ssl_error(self, mock):
-        """Test ssl error."""
+        """Test ssl error in `async request()`."""
         address = 'http://test'
         auth_key = 'passkey'
         # result = 'the result'
@@ -119,7 +116,7 @@ class rest_client_test(unittest.TestCase):
 
     @requests_mock.mock()
     async def test_22_request(self, mock):
-        """Test request."""
+        """Test `async request()`."""
         address = 'http://test'
         auth_key = 'passkey'
         # result = ''
@@ -132,8 +129,8 @@ class rest_client_test(unittest.TestCase):
             _ = await rpc.request('GET','test',{})
 
     @requests_mock.mock()
-    def test_90_request(self, mock):
-        """Test request."""
+    def test_90_request_seq(self, mock):
+        """Test `request_seq()`."""
         address = 'http://test'
         auth_key = 'passkey'
         result = {'result':'the result'}
@@ -151,8 +148,8 @@ class rest_client_test(unittest.TestCase):
         self.assertEqual(ret, result)
 
     @requests_mock.mock()
-    async def test_91_request(self, mock):
-        """Test request."""
+    async def test_91_request_seq(self, mock):
+        """Test `request_seq()`."""
         address = 'http://test'
         auth_key = 'passkey'
         result = {'result':'the result'}
@@ -170,8 +167,8 @@ class rest_client_test(unittest.TestCase):
         self.assertEqual(ret, result)
 
     @requests_mock.mock()
-    async def test_92_request(self, mock):
-        """Test request."""
+    async def test_92_request_seq(self, mock):
+        """Test `request_seq()`."""
         address = 'http://test'
         auth_key = 'passkey'
         # result = {'result':'the result'}

--- a/tests/client/client_test.py
+++ b/tests/client/client_test.py
@@ -206,7 +206,7 @@ def test_100_request_stream() -> None:
                 assert resp == jsonify(expected_stream[i])
 
     # now w/ chunk sizes
-    for chunk_size in [None, 3, 0, -1, 4, 8, 20, 100, 1024, 32768]:
+    for chunk_size in [None, 3, 0, -1, 4, 8, 9, 20, 100, 1024, 32768]:
         print(f"\nchunk_size: {chunk_size}")
         HTTPretty.register_uri(
             HTTPretty.POST,

--- a/tests/client/client_test.py
+++ b/tests/client/client_test.py
@@ -189,6 +189,8 @@ def test_100_request_stream() -> None:
     def jsonify(val: bytes) -> Any:
         return json.loads(val.strip()) if val.strip() else None
 
+    json_stream = [j for t in expected_stream if (j := jsonify(t))]  # no blanks
+
     # test multiple times
     for test_num in range(2):
         print(f"\niteration #{test_num}")
@@ -203,7 +205,7 @@ def test_100_request_stream() -> None:
         with _in_time(0.01, "Iterating by line is taking forever!"):
             for i, resp in enumerate(response_stream):
                 print(f"{resp=}")
-                assert resp == jsonify(expected_stream[i])
+                assert resp == json_stream[i]
 
     # now w/ chunk sizes
     for chunk_size in [None, 3, 0, -1, 4, 8, 9, 20, 100, 1024, 32768]:
@@ -221,4 +223,4 @@ def test_100_request_stream() -> None:
         with _in_time(0.01, "Iterating by line is taking forever w/ chunks!"):
             for i, resp in enumerate(response_stream):
                 print(f"{resp=}")
-                assert resp == jsonify(expected_stream[i])
+                assert resp == json_stream[i]

--- a/tests/client/client_test.py
+++ b/tests/client/client_test.py
@@ -193,12 +193,11 @@ def test_100_request_stream() -> None:
         print(f"\niteration #{test_num}")
         HTTPretty.register_uri(
             HTTPretty.POST,
-            mock_url,
+            mock_url + "/foo/bar/",
             body=(ln for ln in expected_stream),
             streaming=True,
         )
-        # FIXME: add uri/url support
-        response_stream = rpc.request_stream("POST", "", {})
+        response_stream = rpc.request_stream("POST", "/foo/bar/", {})
 
         with _in_time(0.01, "Iterating by line is taking forever!"):
             for i, resp in enumerate(response_stream):
@@ -206,19 +205,19 @@ def test_100_request_stream() -> None:
                 assert resp == jsonify(expected_stream[i])
 
     # now w/ chunk sizes
-    # FIXME: chunk_size<8 fails for `\r\n`
     for chunk_size in [None, 8, 0, -1, 1024, 32768]:
         print(f"\nchunk_size: {chunk_size}")
         HTTPretty.register_uri(
             HTTPretty.POST,
-            mock_url,
+            mock_url + "/foo/bar/",
             body=(ln for ln in expected_stream),
             streaming=True,
         )
-        # FIXME: add uri/url support
-        response_stream = rpc.request_stream("POST", "", {}, chunk_size=chunk_size)
+        response_stream = rpc.request_stream(
+            "POST", "/foo/bar/", {}, chunk_size=chunk_size
+        )
 
-        with _in_time(0.01, "Iterating by line is taking forever!"):
+        with _in_time(0.01, "Iterating by line is taking forever w/ chunks!"):
             for i, resp in enumerate(response_stream):
                 print(f"{resp=}")
                 assert resp == jsonify(expected_stream[i])

--- a/tests/client/client_test.py
+++ b/tests/client/client_test.py
@@ -144,3 +144,20 @@ async def test_92_request_seq(requests_mock: Mock) -> None:
 
     with pytest.raises(Exception):
         rpc.request_seq("POST", "test", {})
+
+
+def test_100_request_stream(requests_mock: Mock) -> None:
+    """Test `request_stream()`."""
+    result = {"result": "the result"}
+    rpc = RestClient("http://test", "passkey", timeout=0.1)
+
+    def response(req: PreparedRequest, ctx: object) -> bytes:  # pylint: disable=W0613
+        assert req.body is not None
+        _ = json_decode(req.body)
+        return json_encode(result).encode("utf-8")
+
+    requests_mock.post("/test", content=response)
+    ret = rpc.request_stream("POST", "test", {})
+
+    assert requests_mock.called
+    assert ret == result


### PR DESCRIPTION
Add `RestClient.request_stream()`:
- Handle bulk responses of multiple JSON documents, yielding as each document is received
- JSON-objects are delimited by the NDJSON format.


closes https://github.com/WIPACrepo/rest-tools/issues/18