### PR TITLE
decrease `open()` ('establish REST http session') logging to debug

### DIFF
--- a/rest_tools/client/client.py
+++ b/rest_tools/client/client.py
@@ -68,7 +68,7 @@ class RestClient:
 
     def open(self, sync: bool = False) -> requests.Session:
         """Open the http session."""
-        self.logger.info('establish REST http session')
+        self.logger.debug('establish REST http session')
         if sync:
             self.session = Session(self.retries)
         else:


### PR DESCRIPTION
The end user shouldn't need to know about sessions unless they explicitly close one / close the RestClient instance.