### PR TITLE
Bump wipac_telemetry dependency to 0.1.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 coverage>=4.4.2
 cryptography
-httpretty==1.0.5
+httpretty==1.1.4
 motor
 pyjwt>=2.0.1
-requests==2.25.1
+requests==2.26.0
 requests-futures
 requests-mock
 requests_toolbelt
 sphinx>=1.4
 tornado>=5.1
 unidecode
-git+https://github.com/WIPACrepo/wipac-telemetry-prototype@v0.1.12#egg=wipac_telemetry
+git+https://github.com/WIPACrepo/wipac-telemetry-prototype@v0.1.14#egg=wipac_telemetry


### PR DESCRIPTION
* This version of wipac_telemetry uses HTTP/JSON to report traces
