### PR TITLE
Add Exports to All Sub-Packages

### DIFF
--- a/rest_tools/client/__init__.py
+++ b/rest_tools/client/__init__.py
@@ -1,2 +1,11 @@
+"""Sub-package __init__."""
+
 from .client import OpenIDRestClient, RestClient
 from .session import AsyncSession, Session
+
+__all__ = [
+    "OpenIDRestClient",
+    "RestClient",
+    "AsyncSession",
+    "Session",
+]

--- a/rest_tools/server/__init__.py
+++ b/rest_tools/server/__init__.py
@@ -1,5 +1,28 @@
-from .server import RestServer
-from .handler import RestHandlerSetup, RestHandler, authenticated, catch_error, role_authorization, scope_role_auth
+"""Sub-package __init__."""
+
 from .auth import Auth, OpenIDAuth
-from .daemon import Daemon
 from .config import from_environment
+from .daemon import Daemon
+from .handler import (
+    RestHandler,
+    RestHandlerSetup,
+    authenticated,
+    catch_error,
+    role_authorization,
+    scope_role_auth,
+)
+from .server import RestServer
+
+__all__ = [
+    "RestServer",
+    "RestHandlerSetup",
+    "RestHandler",
+    "authenticated",
+    "catch_error",
+    "role_authorization",
+    "scope_role_auth",
+    "Auth",
+    "OpenIDAuth",
+    "Daemon",
+    "from_environment",
+]

--- a/rest_tools/utils/__init__.py
+++ b/rest_tools/utils/__init__.py
@@ -1,1 +1,5 @@
+"""Sub-package __init__."""
+
 from . import json_util
+
+__all__ = ["json_util"]


### PR DESCRIPTION
Looks like this was forgotten at some point in the past. We had imports in the `__init__.py`s, but no `__all__`s.