### PR TITLE
Method-Based Span Name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ requests_toolbelt
 sphinx>=1.4
 tornado>=5.1
 unidecode
-git+https://github.com/WIPACrepo/wipac-telemetry-prototype@v0.1.24#egg=wipac_telemetry
+git+https://github.com/WIPACrepo/wipac-telemetry-prototype@v0.1.25#egg=wipac_telemetry

--- a/rest_tools/server/handler.py
+++ b/rest_tools/server/handler.py
@@ -95,6 +95,7 @@ class RestHandler(tornado.web.RequestHandler):
         self.route_stats = route_stats
 
     @wtt.spanned(
+        span_namer=wtt.SpanNamer(use_this_arg='self.request.method'),
         kind=wtt.SpanKind.SERVER,
         these=["self.request.method", "self.request.path"],
         carrier="self.request.headers",


### PR DESCRIPTION
Use `self.request.method` for naming the root span: `"RestHandler._execute:GET"`.

Note: the REST method is actually "GET", "POST", etc. in all caps.