### PR TITLE
create token from service account

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,11 +29,11 @@ requests-futures==1.0.0
     # via wipac-rest-tools (setup.py)
 tornado==6.2
     # via wipac-rest-tools (setup.py)
-types-cryptography==3.3.23
+types-cryptography==3.3.23.1
     # via pyjwt
-typing-extensions==4.3.0
+typing-extensions==4.4.0
     # via wipac-dev-tools
 urllib3==1.26.12
     # via requests
-wipac-dev-tools==1.5.1
+wipac-dev-tools==1.5.6
     # via wipac-rest-tools (setup.py)


### PR DESCRIPTION
Allow creating the tokens directly from a client id/secret via a service account.