### PR TITLE
`get_argument()`: Disallow `None` Values for Strings

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,19 +6,19 @@
 #
 attrs==22.2.0
     # via pytest
-cachetools==5.2.0
+cachetools==5.3.0
     # via wipac-rest-tools (setup.py)
 certifi==2022.12.7
     # via requests
 cffi==1.15.1
     # via cryptography
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via requests
-cryptography==38.0.4
+cryptography==39.0.0
     # via
     #   pyjwt
     #   wipac-rest-tools (setup.py)
-exceptiongroup==1.0.4
+exceptiongroup==1.1.0
     # via pytest
 flake8==6.0.0
     # via wipac-rest-tools (setup.py)
@@ -26,7 +26,7 @@ httpretty==1.1.4
     # via wipac-rest-tools (setup.py)
 idna==3.4
     # via requests
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
 mccabe==0.7.0
     # via flake8
@@ -34,7 +34,7 @@ mypy==0.991
     # via wipac-rest-tools (setup.py)
 mypy-extensions==0.4.3
     # via mypy
-packaging==22.0
+packaging==23.0
     # via pytest
 pluggy==1.0.0
     # via pytest
@@ -46,7 +46,7 @@ pyflakes==3.0.1
     # via flake8
 pyjwt[crypto]==2.5.0
     # via wipac-rest-tools (setup.py)
-pytest==7.2.0
+pytest==7.2.1
     # via
     #   pytest-asyncio
     #   pytest-mock
@@ -57,7 +57,7 @@ pytest-mock==3.10.0
     # via wipac-rest-tools (setup.py)
 qrcode==7.3.1
     # via wipac-rest-tools (setup.py)
-requests==2.28.1
+requests==2.28.2
     # via
     #   requests-futures
     #   requests-mock
@@ -77,7 +77,7 @@ tornado==6.2
     # via wipac-rest-tools (setup.py)
 types-cryptography==3.3.23.2
     # via pyjwt
-types-requests==2.28.11.7
+types-requests==2.28.11.8
     # via wipac-rest-tools (setup.py)
 types-urllib3==1.26.25.4
     # via types-requests
@@ -85,7 +85,7 @@ typing-extensions==4.4.0
     # via
     #   mypy
     #   wipac-dev-tools
-urllib3==1.26.13
+urllib3==1.26.14
     # via requests
 wheel==0.38.4
     # via wipac-rest-tools (setup.py)

--- a/requirements-telemetry.txt
+++ b/requirements-telemetry.txt
@@ -6,17 +6,17 @@
 #
 backoff==2.2.1
     # via opentelemetry-exporter-otlp-proto-http
-cachetools==5.2.0
+cachetools==5.3.0
     # via wipac-rest-tools (setup.py)
 certifi==2022.12.7
     # via requests
 cffi==1.15.1
     # via cryptography
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via requests
 coloredlogs==15.0.1
     # via wipac-telemetry
-cryptography==38.0.4
+cryptography==39.0.0
     # via pyjwt
 deprecated==1.2.13
     # via opentelemetry-api
@@ -66,7 +66,7 @@ pyjwt[crypto]==2.5.0
     # via wipac-rest-tools (setup.py)
 qrcode==7.3.1
     # via wipac-rest-tools (setup.py)
-requests==2.28.1
+requests==2.28.2
     # via
     #   opentelemetry-exporter-otlp-proto-http
     #   requests-futures
@@ -87,7 +87,7 @@ typing-extensions==4.4.0
     #   opentelemetry-sdk
     #   wipac-dev-tools
     #   wipac-telemetry
-urllib3==1.26.13
+urllib3==1.26.14
     # via requests
 wipac-dev-tools==1.6.10
     # via

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -6,13 +6,13 @@
 #
 attrs==22.2.0
     # via pytest
-cachetools==5.2.0
+cachetools==5.3.0
     # via wipac-rest-tools (setup.py)
 certifi==2022.12.7
     # via requests
 cffi==1.15.1
     # via cryptography
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via requests
 click==8.1.3
     # via
@@ -22,15 +22,15 @@ click-completion==0.5.2
     # via pycycle
 colorama==0.4.6
     # via crayons
-coverage[toml]==7.0.0
+coverage[toml]==7.1.0
     # via
     #   pytest-cov
     #   wipac-rest-tools (setup.py)
 crayons==0.4.0
     # via pycycle
-cryptography==38.0.4
+cryptography==39.0.0
     # via pyjwt
-exceptiongroup==1.0.4
+exceptiongroup==1.1.0
     # via pytest
 flake8==6.0.0
     # via wipac-rest-tools (setup.py)
@@ -38,15 +38,15 @@ httpretty==1.1.4
     # via wipac-rest-tools (setup.py)
 idna==3.4
     # via requests
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
 jinja2==3.1.2
     # via click-completion
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via jinja2
 mccabe==0.7.0
     # via flake8
-packaging==22.0
+packaging==23.0
     # via pytest
 pluggy==1.0.0
     # via pytest
@@ -60,7 +60,7 @@ pyflakes==3.0.1
     # via flake8
 pyjwt[crypto]==2.5.0
     # via wipac-rest-tools (setup.py)
-pytest==7.2.0
+pytest==7.2.1
     # via
     #   pycycle
     #   pytest-asyncio
@@ -75,7 +75,7 @@ pytest-mock==3.10.0
     # via wipac-rest-tools (setup.py)
 qrcode==7.3.1
     # via wipac-rest-tools (setup.py)
-requests==2.28.1
+requests==2.28.2
     # via
     #   requests-futures
     #   requests-mock
@@ -85,7 +85,7 @@ requests-futures==1.0.0
     # via wipac-rest-tools (setup.py)
 requests-mock==1.10.0
     # via wipac-rest-tools (setup.py)
-shellingham==1.5.0
+shellingham==1.5.0.post1
     # via click-completion
 six==1.16.0
     # via
@@ -99,13 +99,13 @@ tornado==6.2
     # via wipac-rest-tools (setup.py)
 types-cryptography==3.3.23.2
     # via pyjwt
-types-requests==2.28.11.7
+types-requests==2.28.11.8
     # via wipac-rest-tools (setup.py)
 types-urllib3==1.26.25.4
     # via types-requests
 typing-extensions==4.4.0
     # via wipac-dev-tools
-urllib3==1.26.13
+urllib3==1.26.14
     # via requests
 wipac-dev-tools==1.6.10
     # via wipac-rest-tools (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,15 +4,15 @@
 #
 #    pip-compile --output-file=requirements.txt
 #
-cachetools==5.2.0
+cachetools==5.3.0
     # via wipac-rest-tools (setup.py)
 certifi==2022.12.7
     # via requests
 cffi==1.15.1
     # via cryptography
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via requests
-cryptography==38.0.4
+cryptography==39.0.0
     # via pyjwt
 idna==3.4
     # via requests
@@ -22,7 +22,7 @@ pyjwt[crypto]==2.5.0
     # via wipac-rest-tools (setup.py)
 qrcode==7.3.1
     # via wipac-rest-tools (setup.py)
-requests==2.28.1
+requests==2.28.2
     # via
     #   requests-futures
     #   wipac-dev-tools
@@ -35,7 +35,7 @@ types-cryptography==3.3.23.2
     # via pyjwt
 typing-extensions==4.4.0
     # via wipac-dev-tools
-urllib3==1.26.13
+urllib3==1.26.14
     # via requests
 wipac-dev-tools==1.6.10
     # via wipac-rest-tools (setup.py)

--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -75,6 +75,8 @@ class ArgumentHandler:
                 )
             elif isinstance(value, str) and (type_ == bool) and (value != ""):
                 value = strtobool(value)  # ~> ValueError
+            elif isinstance(value, str) and value is None:
+                raise ValueError("value cannot be cast to 'str' from 'None'")
             else:
                 value = type_(value)  # type: ignore  # ~> ValueError or TypeError
         except (ValueError, TypeError) as e:

--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -75,7 +75,7 @@ class ArgumentHandler:
                 )
             elif isinstance(value, str) and (type_ == bool) and (value != ""):
                 value = strtobool(value)  # ~> ValueError
-            elif isinstance(value, str) and value is None:
+            elif value is None and isinstance(type_, str):  # don't want None -> "None"
                 raise ValueError("value cannot be cast to 'str' from 'None'")
             else:
                 value = type_(value)  # type: ignore  # ~> ValueError or TypeError

--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -75,7 +75,7 @@ class ArgumentHandler:
                 )
             elif isinstance(value, str) and (type_ == bool) and (value != ""):
                 value = strtobool(value)  # ~> ValueError
-            elif value is None and isinstance(type_, str):  # don't want None -> "None"
+            elif value is None and (type_ == str):  # don't want None -> "None"
                 raise ValueError("value cannot be cast to 'str' from 'None'")
             else:
                 value = type_(value)  # type: ignore  # ~> ValueError or TypeError

--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -69,11 +69,7 @@ class ArgumentHandler:
             raise ValueError("argument 'type_' cannot be 'None'")
 
         try:
-            if value is None:
-                raise ValueError(
-                    f"value cannot be cast to '{type_.__name__}' from 'None'"
-                )
-            elif strict_type and not isinstance(value, type_):  # type: ignore[arg-type]
+            if strict_type and not isinstance(value, type_):  # type: ignore[arg-type]
                 raise TypeError(
                     f"type mismatch: '{type_.__name__}' (value is '{type(value)}')"
                 )

--- a/tests/unit_server/arghandler_test.py
+++ b/tests/unit_server/arghandler_test.py
@@ -151,7 +151,7 @@ def test_04_cast_type() -> None:
         {"but this": "is a dict"},
     ]
 
-    def agreeable_type(typ: Any, val: Any) -> bool:
+    def _agreeable_type(typ: Any, val: Any) -> bool:
         if val is None:
             return False
         try:
@@ -164,7 +164,7 @@ def test_04_cast_type() -> None:
         print(val)
         # Passing Cases:
         # assert val == ArgumentHandler._cast_type(val, None)  # None is always allowed
-        for o_type in [type(o) for o in vals if agreeable_type(type(o), val)]:
+        for o_type in [type(o) for o in vals if _agreeable_type(type(o), val)]:
             print(o_type)
             out = ArgumentHandler._cast_type(val, o_type)
             assert isinstance(out, o_type)
@@ -179,7 +179,7 @@ def test_04_cast_type() -> None:
                 ArgumentHandler._cast_type(None, type(val), server_side_error=True)
 
         # type-mismatch  # pylint: disable=C0123
-        for o_type in [type(o) for o in vals if not agreeable_type(type(o), val)]:
+        for o_type in [type(o) for o in vals if not _agreeable_type(type(o), val)]:
             print(o_type)
             with pytest.raises(_InvalidArgumentError):
                 ArgumentHandler._cast_type(val, o_type)

--- a/tests/unit_server/arghandler_test.py
+++ b/tests/unit_server/arghandler_test.py
@@ -171,11 +171,11 @@ def test_04_cast_type() -> None:
 
         # Error Cases:
 
-        # None is not allowed
+        # None is not allowed (unless the type is type(None))
         if val is not None:
             with pytest.raises(_InvalidArgumentError):
                 ArgumentHandler._cast_type(None, type(val))
-            with pytest.raises(ValueError):
+            with pytest.raises((ValueError, TypeError)):
                 ArgumentHandler._cast_type(None, type(val), server_side_error=True)
 
         # type-mismatch  # pylint: disable=C0123


### PR DESCRIPTION
`default=None` is useful when there is no value sent by the requestor (given the correct type lambda/function). Most built-in types error when casting `None` (as expected), except `str`.

closes #96 