### PR TITLE
Add regex matching for `choices` & `forbiddens`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,19 +6,19 @@
 #
 attrs==22.2.0
     # via pytest
-cachetools==5.2.0
+cachetools==5.3.0
     # via wipac-rest-tools (setup.py)
 certifi==2022.12.7
     # via requests
 cffi==1.15.1
     # via cryptography
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via requests
-cryptography==38.0.4
+cryptography==39.0.0
     # via
     #   pyjwt
     #   wipac-rest-tools (setup.py)
-exceptiongroup==1.0.4
+exceptiongroup==1.1.0
     # via pytest
 flake8==6.0.0
     # via wipac-rest-tools (setup.py)
@@ -26,7 +26,7 @@ httpretty==1.1.4
     # via wipac-rest-tools (setup.py)
 idna==3.4
     # via requests
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
 mccabe==0.7.0
     # via flake8
@@ -34,7 +34,7 @@ mypy==0.991
     # via wipac-rest-tools (setup.py)
 mypy-extensions==0.4.3
     # via mypy
-packaging==22.0
+packaging==23.0
     # via pytest
 pluggy==1.0.0
     # via pytest
@@ -46,7 +46,7 @@ pyflakes==3.0.1
     # via flake8
 pyjwt[crypto]==2.5.0
     # via wipac-rest-tools (setup.py)
-pytest==7.2.0
+pytest==7.2.1
     # via
     #   pytest-asyncio
     #   pytest-mock
@@ -57,7 +57,7 @@ pytest-mock==3.10.0
     # via wipac-rest-tools (setup.py)
 qrcode==7.3.1
     # via wipac-rest-tools (setup.py)
-requests==2.28.1
+requests==2.28.2
     # via
     #   requests-futures
     #   requests-mock
@@ -77,7 +77,7 @@ tornado==6.2
     # via wipac-rest-tools (setup.py)
 types-cryptography==3.3.23.2
     # via pyjwt
-types-requests==2.28.11.7
+types-requests==2.28.11.8
     # via wipac-rest-tools (setup.py)
 types-urllib3==1.26.25.4
     # via types-requests
@@ -85,7 +85,7 @@ typing-extensions==4.4.0
     # via
     #   mypy
     #   wipac-dev-tools
-urllib3==1.26.13
+urllib3==1.26.14
     # via requests
 wheel==0.38.4
     # via wipac-rest-tools (setup.py)

--- a/requirements-telemetry.txt
+++ b/requirements-telemetry.txt
@@ -6,17 +6,17 @@
 #
 backoff==2.2.1
     # via opentelemetry-exporter-otlp-proto-http
-cachetools==5.2.0
+cachetools==5.3.0
     # via wipac-rest-tools (setup.py)
 certifi==2022.12.7
     # via requests
 cffi==1.15.1
     # via cryptography
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via requests
 coloredlogs==15.0.1
     # via wipac-telemetry
-cryptography==38.0.4
+cryptography==39.0.0
     # via pyjwt
 deprecated==1.2.13
     # via opentelemetry-api
@@ -66,7 +66,7 @@ pyjwt[crypto]==2.5.0
     # via wipac-rest-tools (setup.py)
 qrcode==7.3.1
     # via wipac-rest-tools (setup.py)
-requests==2.28.1
+requests==2.28.2
     # via
     #   opentelemetry-exporter-otlp-proto-http
     #   requests-futures
@@ -87,7 +87,7 @@ typing-extensions==4.4.0
     #   opentelemetry-sdk
     #   wipac-dev-tools
     #   wipac-telemetry
-urllib3==1.26.13
+urllib3==1.26.14
     # via requests
 wipac-dev-tools==1.6.10
     # via

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -6,13 +6,13 @@
 #
 attrs==22.2.0
     # via pytest
-cachetools==5.2.0
+cachetools==5.3.0
     # via wipac-rest-tools (setup.py)
 certifi==2022.12.7
     # via requests
 cffi==1.15.1
     # via cryptography
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via requests
 click==8.1.3
     # via
@@ -22,15 +22,15 @@ click-completion==0.5.2
     # via pycycle
 colorama==0.4.6
     # via crayons
-coverage[toml]==7.0.0
+coverage[toml]==7.1.0
     # via
     #   pytest-cov
     #   wipac-rest-tools (setup.py)
 crayons==0.4.0
     # via pycycle
-cryptography==38.0.4
+cryptography==39.0.0
     # via pyjwt
-exceptiongroup==1.0.4
+exceptiongroup==1.1.0
     # via pytest
 flake8==6.0.0
     # via wipac-rest-tools (setup.py)
@@ -38,15 +38,15 @@ httpretty==1.1.4
     # via wipac-rest-tools (setup.py)
 idna==3.4
     # via requests
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
 jinja2==3.1.2
     # via click-completion
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via jinja2
 mccabe==0.7.0
     # via flake8
-packaging==22.0
+packaging==23.0
     # via pytest
 pluggy==1.0.0
     # via pytest
@@ -60,7 +60,7 @@ pyflakes==3.0.1
     # via flake8
 pyjwt[crypto]==2.5.0
     # via wipac-rest-tools (setup.py)
-pytest==7.2.0
+pytest==7.2.1
     # via
     #   pycycle
     #   pytest-asyncio
@@ -75,7 +75,7 @@ pytest-mock==3.10.0
     # via wipac-rest-tools (setup.py)
 qrcode==7.3.1
     # via wipac-rest-tools (setup.py)
-requests==2.28.1
+requests==2.28.2
     # via
     #   requests-futures
     #   requests-mock
@@ -85,7 +85,7 @@ requests-futures==1.0.0
     # via wipac-rest-tools (setup.py)
 requests-mock==1.10.0
     # via wipac-rest-tools (setup.py)
-shellingham==1.5.0
+shellingham==1.5.0.post1
     # via click-completion
 six==1.16.0
     # via
@@ -99,13 +99,13 @@ tornado==6.2
     # via wipac-rest-tools (setup.py)
 types-cryptography==3.3.23.2
     # via pyjwt
-types-requests==2.28.11.7
+types-requests==2.28.11.8
     # via wipac-rest-tools (setup.py)
 types-urllib3==1.26.25.4
     # via types-requests
 typing-extensions==4.4.0
     # via wipac-dev-tools
-urllib3==1.26.13
+urllib3==1.26.14
     # via requests
 wipac-dev-tools==1.6.10
     # via wipac-rest-tools (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,15 +4,15 @@
 #
 #    pip-compile --output-file=requirements.txt
 #
-cachetools==5.2.0
+cachetools==5.3.0
     # via wipac-rest-tools (setup.py)
 certifi==2022.12.7
     # via requests
 cffi==1.15.1
     # via cryptography
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via requests
-cryptography==38.0.4
+cryptography==39.0.0
     # via pyjwt
 idna==3.4
     # via requests
@@ -22,7 +22,7 @@ pyjwt[crypto]==2.5.0
     # via wipac-rest-tools (setup.py)
 qrcode==7.3.1
     # via wipac-rest-tools (setup.py)
-requests==2.28.1
+requests==2.28.2
     # via
     #   requests-futures
     #   wipac-dev-tools
@@ -35,7 +35,7 @@ types-cryptography==3.3.23.2
     # via pyjwt
 typing-extensions==4.4.0
     # via wipac-dev-tools
-urllib3==1.26.13
+urllib3==1.26.14
     # via requests
 wipac-dev-tools==1.6.10
     # via wipac-rest-tools (setup.py)

--- a/rest_tools/server/handler.py
+++ b/rest_tools/server/handler.py
@@ -216,8 +216,8 @@ class RestHandler(tornado.web.RequestHandler):
         Keyword Arguments:
             default -- a default value to use if the argument is not present
             type -- typecast (or call a one-argument callable) with the argument's value (raise `400` for ValueError and/or TypeError)
-            choices -- a list of valid argument values (raise `400`, if arg's value is not in list)
-            forbiddens -- a list of disallowed argument values (raise `400`, if arg's value is in list)
+            choices -- a list of valid argument values; regex is allowed for strings (raise `400`, if arg's value is not in list)
+            forbiddens -- a list of disallowed argument values; regex is allowed for strings (raise `400`, if arg's value is in list)
             strict_type -- if True and `type` is passed, the arg's value is type-checked instead of type-casted
 
         Returns:
@@ -248,8 +248,8 @@ class RestHandler(tornado.web.RequestHandler):
             default -- a default value to use if the argument is not present
             strip {`bool`} -- whether to `str.strip()` the arg's value (default: {`True`})
             type -- typecast (or call a one-argument callable) with the argument's value (raise `400` for ValueError and/or TypeError)
-            choices -- a list of valid argument values (raise `400`, if arg's value is not in list)
-            forbiddens -- a list of disallowed argument values (raise `400`, if arg's value is in list)
+            choices -- a list of valid argument values; regex is allowed for strings (raise `400`, if arg's value is not in list)
+            forbiddens -- a list of disallowed argument values; regex is allowed for strings(raise `400`, if arg's value is in list)
             strict_type -- if True and `type` is passed, the arg's value is type-checked instead of type-casted
 
         Returns:
@@ -269,8 +269,7 @@ class RestHandler(tornado.web.RequestHandler):
 
 
 class KeycloakUsernameMixin:
-    """
-    Get the username correctly from Keycloak tokens.
+    """Get the username correctly from Keycloak tokens.
 
     Note: will not work on service account tokens.
     """
@@ -286,8 +285,7 @@ class KeycloakUsernameMixin:
 
 
 class OpenIDLoginHandler(RestHandler, OAuth2Mixin):
-    """
-    Handle OpenID Connect logins.
+    """Handle OpenID Connect logins.
 
     Requires the `login_url` application setting to be a full url.
     """

--- a/tests/unit_server/arghandler_test.py
+++ b/tests/unit_server/arghandler_test.py
@@ -98,6 +98,7 @@ def test_02_validate_choice() -> None:
     assert ArgumentHandler._validate_choice(1, [0, 1, 2], None) == 1
     assert ArgumentHandler._validate_choice("", [""], None) == ""
     ArgumentHandler._validate_choice("23", [23, "23"], None)
+    ArgumentHandler._validate_choice("23", [23, r"\d\d"], None)  # regex
 
     # forbiddens
     ArgumentHandler._validate_choice("23", [23, "23"], [])
@@ -111,15 +112,19 @@ def test_03_validate_choice__errors() -> None:
     with pytest.raises(_InvalidArgumentError) as e:
         ArgumentHandler._validate_choice("23", [23], None)
     assert "(ValueError)" in str(e.value) and "not in choices" in str(e.value)
+    #
     with pytest.raises(_InvalidArgumentError) as e:
         ArgumentHandler._validate_choice("string", ["STRING"], None)
     assert "(ValueError)" in str(e.value) and "not in choices" in str(e.value)
+    #
     with pytest.raises(_InvalidArgumentError) as e:
         ArgumentHandler._validate_choice("3", [0, 1, 2], None)
     assert "(ValueError)" in str(e.value) and "not in choices" in str(e.value)
+    #
     with pytest.raises(_InvalidArgumentError) as e:
         ArgumentHandler._validate_choice("abc", [["a", "b", "c", "d"]], None)
     assert "(ValueError)" in str(e.value) and "not in choices" in str(e.value)
+    #
     with pytest.raises(_InvalidArgumentError) as e:
         ArgumentHandler._validate_choice("foo", [], [])  # no allowed choices
     assert "(ValueError)" in str(e.value) and "not in choices" in str(e.value)
@@ -128,14 +133,21 @@ def test_03_validate_choice__errors() -> None:
     with pytest.raises(_InvalidArgumentError) as e:
         ArgumentHandler._validate_choice("23", None, ["23"])
     assert "(ValueError)" in str(e.value) and "is forbidden" in str(e.value)
+    #
     with pytest.raises(_InvalidArgumentError) as e:
         ArgumentHandler._validate_choice("baz", ["baz"], ["baz"])
     assert "(ValueError)" in str(e.value) and "is forbidden" in str(e.value)
+    #
     with pytest.raises(_InvalidArgumentError) as e:
         ArgumentHandler._validate_choice([], None, [list(), dict()])
     assert "(ValueError)" in str(e.value) and "is forbidden" in str(e.value)
+    #
     with pytest.raises(_InvalidArgumentError) as e:
         ArgumentHandler._validate_choice({}, None, [list(), dict()])
+    assert "(ValueError)" in str(e.value) and "is forbidden" in str(e.value)
+    #
+    with pytest.raises(_InvalidArgumentError) as e:
+        ArgumentHandler._validate_choice("   ", None, [123, r"\s*"])  # regex
     assert "(ValueError)" in str(e.value) and "is forbidden" in str(e.value)
 
 


### PR DESCRIPTION
Regex is handy for string matching. This will also allow prohibiting empty-strings & whitespace strings.

related https://github.com/WIPACrepo/rest-tools/issues/95