### PR TITLE
add a handler mixin for openid auth user detection

### DIFF
--- a/rest_tools/server/__init__.py
+++ b/rest_tools/server/__init__.py
@@ -12,6 +12,7 @@ from .decorators import (
 from .handler import (
     RestHandler,
     RestHandlerSetup,
+    OpenIDWebHandlerMixin,
     KeycloakUsernameMixin,
     OpenIDLoginHandler,
 )
@@ -21,6 +22,7 @@ __all__ = [
     "RestServer",
     "RestHandlerSetup",
     "RestHandler",
+    "OpenIDWebHandlerMixin",
     "KeycloakUsernameMixin",
     "OpenIDLoginHandler",
     "authenticated",

--- a/rest_tools/server/handler.py
+++ b/rest_tools/server/handler.py
@@ -268,6 +268,25 @@ class RestHandler(tornado.web.RequestHandler):
         )
 
 
+class OpenIDWebHandlerMixin:
+    """Load current user from `OpenIDLoginHandler` cookies."""
+    def get_current_user(self):
+        """Get the current user, and set auth-related attributes."""
+        try:
+            access_token = self.get_secure_cookie('access_token')
+            refresh_token = self.get_secure_cookie('refresh_token')
+            data = self.auth.validate(access_token)
+            self.auth_data = data
+            self.auth_key = access_token
+            self.auth_refresh_token = refresh_token
+            return data['sub']
+        # Auth Failed
+        except Exception:
+            logger.info('failed auth', exc_info=True)
+
+        return None
+
+
 class KeycloakUsernameMixin:
     """Get the username correctly from Keycloak tokens.
 

--- a/tests/unit_server/rest_handler_test.py
+++ b/tests/unit_server/rest_handler_test.py
@@ -104,6 +104,7 @@ def test_openid_web_handler_mixin():
     assert rh.get_current_user() is None
 
     token = a.create_token('subject', payload={'foo': 'bar'})
+
     def get_token(name):
         if name == 'access_token':
             return token
@@ -111,6 +112,7 @@ def test_openid_web_handler_mixin():
             return ''
         else:
             return {}
+
     rh.get_secure_cookie = MagicMock(side_effect=get_token)
 
     assert rh.get_current_user() == 'subject'

--- a/tests/unit_server/rest_handler_test.py
+++ b/tests/unit_server/rest_handler_test.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock
 
 import jwt.algorithms
 import pytest
-from rest_tools.server import OpenIDLoginHandler, RestHandler, RestHandlerSetup, KeycloakUsernameMixin
+from rest_tools.server import OpenIDLoginHandler, RestHandler, RestHandlerSetup, OpenIDWebHandlerMixin, KeycloakUsernameMixin
 from rest_tools.utils.auth import Auth, OpenIDAuth
 from tornado.web import Application, HTTPError
 
@@ -89,6 +89,33 @@ def test_rest_handler_get_argument():
 
     with pytest.raises(Exception):
         rh.get_argument('baz')
+
+
+def test_openid_web_handler_mixin():
+    a = Auth('secret')
+
+    class A(OpenIDWebHandlerMixin, RestHandler):
+        pass
+
+    rh = A()
+    rh.initialize(auth=a)
+    rh.get_secure_cookie = MagicMock(return_value='')
+
+    assert rh.get_current_user() is None
+
+    token = a.create_token('subject', payload={'foo': 'bar'})
+    def get_token(name):
+        if name == 'access_token':
+            return token
+        elif name == 'refresh_token':
+            return ''
+        else:
+            return {}
+    rh.get_secure_cookie = MagicMock(side_effect=get_token)
+
+    assert rh.get_current_user() == 'subject'
+    assert rh.auth_data['foo'] == 'bar'
+    assert rh.auth_key == token
 
 
 def test_keycloak_username_mixin():


### PR DESCRIPTION
Designed to match `OpenIDLoginHandler` and allow `get_current_user()` to work for non-api websites.