### PR TITLE
allow method to return non-awaitable in decorators

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -57,7 +57,7 @@ pytest-asyncio==0.20.3
     # via wipac-rest-tools (setup.py)
 pytest-mock==3.10.0
     # via wipac-rest-tools (setup.py)
-qrcode==7.4
+qrcode==7.4.1
     # via wipac-rest-tools (setup.py)
 requests==2.28.2
     # via

--- a/requirements-telemetry.txt
+++ b/requirements-telemetry.txt
@@ -66,7 +66,7 @@ pyjwt[crypto]==2.5.0
     # via wipac-rest-tools (setup.py)
 pypng==0.20220715.0
     # via qrcode
-qrcode==7.4
+qrcode==7.4.1
     # via wipac-rest-tools (setup.py)
 requests==2.28.2
     # via

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -75,7 +75,7 @@ pytest-cov==4.0.0
     # via wipac-rest-tools (setup.py)
 pytest-mock==3.10.0
     # via wipac-rest-tools (setup.py)
-qrcode==7.4
+qrcode==7.4.1
     # via wipac-rest-tools (setup.py)
 requests==2.28.2
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ pyjwt[crypto]==2.5.0
     # via wipac-rest-tools (setup.py)
 pypng==0.20220715.0
     # via qrcode
-qrcode==7.4
+qrcode==7.4.1
     # via wipac-rest-tools (setup.py)
 requests==2.28.2
     # via


### PR DESCRIPTION
Particularly important if using `tornado.web.authenticated` for non-REST routes, as it will return `None` on failure since it's a redirect, not an exception.