### PR TITLE
allow OpenIDWebHandlerMixin to decode byte or str for the access token

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ cffi==1.15.1
     # via cryptography
 charset-normalizer==3.0.1
     # via requests
-cryptography==39.0.0
+cryptography==39.0.1
     # via
     #   pyjwt
     #   wipac-rest-tools (setup.py)
@@ -30,7 +30,7 @@ iniconfig==2.0.0
     # via pytest
 mccabe==0.7.0
     # via flake8
-mypy==0.991
+mypy==1.0.0
     # via wipac-rest-tools (setup.py)
 mypy-extensions==1.0.0
     # via mypy
@@ -79,11 +79,11 @@ tornado==6.2
     # via wipac-rest-tools (setup.py)
 types-cryptography==3.3.23.2
     # via pyjwt
-types-requests==2.28.11.8
+types-requests==2.28.11.13
     # via wipac-rest-tools (setup.py)
-types-urllib3==1.26.25.4
+types-urllib3==1.26.25.6
     # via types-requests
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   mypy
     #   qrcode

--- a/requirements-telemetry.txt
+++ b/requirements-telemetry.txt
@@ -16,7 +16,7 @@ charset-normalizer==3.0.1
     # via requests
 coloredlogs==15.0.1
     # via wipac-telemetry
-cryptography==39.0.0
+cryptography==39.0.1
     # via pyjwt
 deprecated==1.2.13
     # via opentelemetry-api
@@ -84,7 +84,7 @@ tornado==6.2
     # via wipac-rest-tools (setup.py)
 types-cryptography==3.3.23.2
     # via pyjwt
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   opentelemetry-sdk
     #   qrcode

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -28,7 +28,7 @@ coverage[toml]==7.1.0
     #   wipac-rest-tools (setup.py)
 crayons==0.4.0
     # via pycycle
-cryptography==39.0.0
+cryptography==39.0.1
     # via pyjwt
 exceptiongroup==1.1.0
     # via pytest
@@ -101,11 +101,11 @@ tornado==6.2
     # via wipac-rest-tools (setup.py)
 types-cryptography==3.3.23.2
     # via pyjwt
-types-requests==2.28.11.8
+types-requests==2.28.11.13
     # via wipac-rest-tools (setup.py)
-types-urllib3==1.26.25.4
+types-urllib3==1.26.25.6
     # via types-requests
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   qrcode
     #   wipac-dev-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ cffi==1.15.1
     # via cryptography
 charset-normalizer==3.0.1
     # via requests
-cryptography==39.0.0
+cryptography==39.0.1
     # via pyjwt
 idna==3.4
     # via requests
@@ -35,7 +35,7 @@ tornado==6.2
     # via wipac-rest-tools (setup.py)
 types-cryptography==3.3.23.2
     # via pyjwt
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   qrcode
     #   wipac-dev-tools

--- a/rest_tools/server/handler.py
+++ b/rest_tools/server/handler.py
@@ -274,7 +274,10 @@ class OpenIDWebHandlerMixin:
         """Get the current user, and set auth-related attributes."""
         try:
             access_token = self.get_secure_cookie('access_token')
+            logging.debug('access_token: %r', access_token)
             refresh_token = self.get_secure_cookie('refresh_token')
+            if isinstance(access_token, str):
+                access_token = access_token.encode('utf8')
             data = self.auth.validate(access_token)
             self.auth_data = data
             self.auth_key = access_token

--- a/rest_tools/utils/auth.py
+++ b/rest_tools/utils/auth.py
@@ -20,7 +20,7 @@ class _AuthValidate:
 
         # required claims
         claims = ['exp', 'iat', 'iss']
-        claims.extend(kwargs.pop('require', []))
+        claims.extend(kwargs.pop('required', []))
         options['require'] = claims
 
         # configure the audience to validate

--- a/tests/unit_server/rest_handler_test.py
+++ b/tests/unit_server/rest_handler_test.py
@@ -103,7 +103,7 @@ def test_openid_web_handler_mixin():
 
     assert rh.get_current_user() is None
 
-    token = a.create_token('subject', payload={'foo': 'bar'})
+    token = a.create_token('subject', payload={'foo': 'bar'}).encode()
 
     def get_token(name):
         if name == 'access_token':


### PR DESCRIPTION
This fixes an iceprod test case, though curiously prod is fine the way it is.