### PR TITLE
work around previous .well-known discovery failures

### DIFF
--- a/rest_tools/client/client_credentials.py
+++ b/rest_tools/client/client_credentials.py
@@ -35,6 +35,9 @@ class ClientCredentialsAuth(RestClient):
                          **kwargs)
 
     def make_access_token(self) -> str:
+        if not self.auth.token_url:
+            self.auth._refresh_keys()
+
         # try making a new token
         args = {
             'grant_type': 'client_credentials',

--- a/rest_tools/client/device_client.py
+++ b/rest_tools/client/device_client.py
@@ -180,15 +180,16 @@ def SavedDeviceGrantAuth(
     """
     logger = logging.getLogger('SavedDeviceGrantAuth')
 
-    auth = OpenIDAuth(token_url)
-    if 'device_authorization_endpoint' not in auth.provider_info:
-        raise RuntimeError('Device grant not supported by server')
-    endpoint = auth.provider_info['device_authorization_endpoint']
-
     filepath = Path(filename)
     refresh_token = _load_token_from_file(filepath)
 
     if not refresh_token:
+        auth = OpenIDAuth(token_url)
+        if not auth.provider_info:
+            raise RuntimeError('Token service does not support .well-known discovery')
+        if 'device_authorization_endpoint' not in auth.provider_info:
+            raise RuntimeError('Device grant not supported by server')
+        endpoint = auth.provider_info['device_authorization_endpoint']
         refresh_token = _perform_device_grant(logger, endpoint, auth.token_url, client_id, client_secret, scopes)
 
     def update_func(access, refresh):

--- a/rest_tools/client/openid_client.py
+++ b/rest_tools/client/openid_client.py
@@ -53,6 +53,9 @@ class OpenIDRestClient(RestClient):
         self._openid_token()
 
     def _openid_token(self) -> str:
+        if not self.auth.token_url:
+            self.auth._refresh_keys()
+
         # try the refresh token
         args = {
             'grant_type': 'refresh_token',


### PR DESCRIPTION
It was discovered that a client_credentials client that failed to connect to keycloak at the start would keep retrying to generate a token, but failed because the token_url was `None`.  Test for this and try getting the url again if necessary.