### PR TITLE
try refreshing saved token before skipping device code

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ cffi==1.15.1
     # via cryptography
 charset-normalizer==3.1.0
     # via requests
-cryptography==39.0.2
+cryptography==40.0.1
     # via
     #   pyjwt
     #   wipac-rest-tools (setup.py)
@@ -53,7 +53,7 @@ pytest==7.2.2
     #   pytest-asyncio
     #   pytest-mock
     #   wipac-rest-tools (setup.py)
-pytest-asyncio==0.20.3
+pytest-asyncio==0.21.0
     # via wipac-rest-tools (setup.py)
 pytest-mock==3.10.0
     # via wipac-rest-tools (setup.py)
@@ -69,7 +69,7 @@ requests-futures==1.0.0
     # via wipac-rest-tools (setup.py)
 requests-mock==1.10.0
     # via wipac-rest-tools (setup.py)
-ruff==0.0.256
+ruff==0.0.260
     # via wipac-rest-tools (setup.py)
 six==1.16.0
     # via requests-mock
@@ -81,9 +81,9 @@ tornado==6.2
     # via wipac-rest-tools (setup.py)
 types-cryptography==3.3.23.2
     # via pyjwt
-types-requests==2.28.11.15
+types-requests==2.28.11.17
     # via wipac-rest-tools (setup.py)
-types-urllib3==1.26.25.8
+types-urllib3==1.26.25.10
     # via types-requests
 typing-extensions==4.5.0
     # via

--- a/requirements-telemetry.txt
+++ b/requirements-telemetry.txt
@@ -16,7 +16,7 @@ charset-normalizer==3.1.0
     # via requests
 coloredlogs==15.0.1
     # via wipac-telemetry
-cryptography==39.0.2
+cryptography==40.0.1
     # via pyjwt
 deprecated==1.2.13
     # via opentelemetry-api
@@ -24,36 +24,38 @@ googleapis-common-protos==1.56.2
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.51.3
+grpcio==1.53.0
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs
 idna==3.4
     # via requests
-opentelemetry-api==1.16.0
+importlib-metadata==6.0.1
+    # via opentelemetry-api
+opentelemetry-api==1.17.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   wipac-telemetry
-opentelemetry-exporter-jaeger==1.16.0
+opentelemetry-exporter-jaeger==1.17.0
     # via wipac-telemetry
-opentelemetry-exporter-jaeger-proto-grpc==1.16.0
+opentelemetry-exporter-jaeger-proto-grpc==1.17.0
     # via opentelemetry-exporter-jaeger
-opentelemetry-exporter-jaeger-thrift==1.16.0
+opentelemetry-exporter-jaeger-thrift==1.17.0
     # via opentelemetry-exporter-jaeger
-opentelemetry-exporter-otlp-proto-http==1.16.0
+opentelemetry-exporter-otlp-proto-http==1.17.0
     # via wipac-telemetry
-opentelemetry-proto==1.16.0
+opentelemetry-proto==1.17.0
     # via opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.16.0
+opentelemetry-sdk==1.17.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   wipac-telemetry
-opentelemetry-semantic-conventions==0.37b0
+opentelemetry-semantic-conventions==0.38b0
     # via opentelemetry-sdk
 protobuf==3.20.3
     # via
@@ -100,6 +102,8 @@ wipac-telemetry==0.2.5
     # via wipac-rest-tools (setup.py)
 wrapt==1.15.0
     # via deprecated
+zipp==3.15.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -28,7 +28,7 @@ coverage[toml]==7.2.2
     #   wipac-rest-tools (setup.py)
 crayons==0.4.0
     # via pycycle
-cryptography==39.0.2
+cryptography==40.0.1
     # via pyjwt
 exceptiongroup==1.1.1
     # via pytest
@@ -69,7 +69,7 @@ pytest==7.2.2
     #   pytest-cov
     #   pytest-mock
     #   wipac-rest-tools (setup.py)
-pytest-asyncio==0.20.3
+pytest-asyncio==0.21.0
     # via wipac-rest-tools (setup.py)
 pytest-cov==4.0.0
     # via wipac-rest-tools (setup.py)
@@ -87,7 +87,7 @@ requests-futures==1.0.0
     # via wipac-rest-tools (setup.py)
 requests-mock==1.10.0
     # via wipac-rest-tools (setup.py)
-ruff==0.0.256
+ruff==0.0.260
     # via wipac-rest-tools (setup.py)
 shellingham==1.5.0.post1
     # via click-completion
@@ -103,9 +103,9 @@ tornado==6.2
     # via wipac-rest-tools (setup.py)
 types-cryptography==3.3.23.2
     # via pyjwt
-types-requests==2.28.11.15
+types-requests==2.28.11.17
     # via wipac-rest-tools (setup.py)
-types-urllib3==1.26.25.8
+types-urllib3==1.26.25.10
     # via types-requests
 typing-extensions==4.5.0
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ cffi==1.15.1
     # via cryptography
 charset-normalizer==3.1.0
     # via requests
-cryptography==39.0.2
+cryptography==40.0.1
     # via pyjwt
 idna==3.4
     # via requests

--- a/rest_tools/client/device_client.py
+++ b/rest_tools/client/device_client.py
@@ -186,26 +186,28 @@ def SavedDeviceGrantAuth(
     """
     logger = logging.getLogger('SavedDeviceGrantAuth')
 
+    filepath = Path(filename)
+    def update_func(access, refresh):
+        _save_token_to_file(filepath, refresh)
+
+    refresh_token = _load_token_from_file(filepath)
+    if refresh_token:
+        try:
+            # this will try to refresh, and raise if it fails
+            return OpenIDRestClient(address=address, token_url=token_url, client_id=client_id,
+                                    client_secret=client_secret, refresh_token=refresh_token,
+                                    update_func=update_func, **kwargs)
+        except Exception:
+            pass
+
     auth = OpenIDAuth(token_url)
     if not auth.provider_info:
         raise RuntimeError('Token service does not support .well-known discovery')
     if 'device_authorization_endpoint' not in auth.provider_info:
         raise RuntimeError('Device grant not supported by server')
+    endpoint = auth.provider_info['device_authorization_endpoint']
 
-    filepath = Path(filename)
-    refresh_token = _load_token_from_file(filepath)
-    if refresh_token:
-        try:
-            auth.validate(refresh_token)
-        except Exception:
-            refresh_token = None
-
-    if not refresh_token:
-        endpoint = auth.provider_info['device_authorization_endpoint']
-        refresh_token = _perform_device_grant(logger, endpoint, auth.token_url, client_id, client_secret, scopes)
-
-    def update_func(access, refresh):
-        _save_token_to_file(filepath, refresh)
+    refresh_token = _perform_device_grant(logger, endpoint, auth.token_url, client_id, client_secret, scopes)
 
     return OpenIDRestClient(address=address, token_url=token_url, client_id=client_id,
                             client_secret=client_secret, refresh_token=refresh_token,

--- a/rest_tools/client/device_client.py
+++ b/rest_tools/client/device_client.py
@@ -185,8 +185,8 @@ def SavedDeviceGrantAuth(
         retries (int): number of retries to attempt (optional)
     """
     logger = logging.getLogger('SavedDeviceGrantAuth')
-
     filepath = Path(filename)
+
     def update_func(access, refresh):
         _save_token_to_file(filepath, refresh)
 

--- a/tests/unit_client/device_client_test.py
+++ b/tests/unit_client/device_client_test.py
@@ -294,4 +294,4 @@ def test_111_saved_expired_token(well_known_mock, requests_mock, tmp_path) -> No
 
     assert filepath.read_text() == token_result['refresh_token']
     assert mock_device.call_count == 1
-    assert mock_refresh.call_count == 2
+    assert mock_refresh.call_count == 3

--- a/tests/unit_client/device_client_test.py
+++ b/tests/unit_client/device_client_test.py
@@ -248,8 +248,8 @@ def test_110_saved_good_token(well_known_mock, requests_mock, tmp_path) -> None:
     SavedDeviceGrantAuth('http://test-api', 'http://test', filename=str(filepath), client_id='client-id')
 
     assert filepath.read_text() == token_result['refresh_token']
-    assert mock_device.called == 0
-    assert mock_refresh.called == 1
+    assert mock_device.call_count == 0
+    assert mock_refresh.call_count == 1
 
 
 def test_111_saved_expired_token(well_known_mock, requests_mock, tmp_path) -> None:
@@ -293,5 +293,5 @@ def test_111_saved_expired_token(well_known_mock, requests_mock, tmp_path) -> No
     SavedDeviceGrantAuth('http://test-api', 'http://test', filename=str(filepath), client_id='client-id')
 
     assert filepath.read_text() == token_result['refresh_token']
-    assert mock_device.called == 1
-    assert mock_refresh.called == 2
+    assert mock_device.call_count == 1
+    assert mock_refresh.call_count == 2

--- a/tests/unit_client/device_client_test.py
+++ b/tests/unit_client/device_client_test.py
@@ -211,3 +211,44 @@ def test_101_load_save(tmp_path) -> None:
 
     _save_token_to_file(filepath, token)
     assert token == _load_token_from_file(filepath)
+
+
+def test_110_saved_expired_token(well_known_mock, requests_mock, tmp_path) -> None:
+    device_result = {
+        'device_code': 'XXXXXXXXXXXXXXXXXXXXXXXX',
+        'user_code': 'XXXX-XXXX',
+        'verification_uri': 'http://test/device_verification',
+        'expires_in': 600,
+        'interval': 0.1,
+    }
+
+    def response(req: PreparedRequest, ctx: Any) -> bytes:  # pylint: disable=W0613
+        assert req.body is not None
+        body = urllib.parse.parse_qs(str(req.body))
+        logging.debug('device request args: %r', body)
+        assert body['client_id'][0] == 'client-id'
+        return json_encode(device_result).encode("utf-8")
+    requests_mock.post('http://test/device', content=response)
+
+    token_result = {
+        'access_token': 'XXXXXXXXXXXXX',
+        'refresh_token': 'YYYYYYYYYYYYY',
+        'token_type': 'bearer',
+    }
+
+    def response2(req: PreparedRequest, ctx: Any) -> bytes:  # pylint: disable=W0613
+        assert req.body is not None
+        body = urllib.parse.parse_qs(str(req.body))
+        logging.debug('token request args: %r', body)
+        assert body['client_id'][0] == 'client-id'
+        if body['grant_type'][0] != 'refresh_token':
+            assert body['grant_type'][0] == 'urn:ietf:params:oauth:grant-type:device_code'
+            assert body['device_code'][0] == device_result['device_code']
+        return json_encode(token_result).encode("utf-8")
+    requests_mock.post('http://test/token', content=response2)
+
+    filepath = tmp_path / 'foo'
+    _save_token_to_file(filepath, 'badtoken')
+    SavedDeviceGrantAuth('http://test-api', 'http://test', filename=str(filepath), client_id='client-id')
+
+    assert filepath.read_text() == token_result['refresh_token']


### PR DESCRIPTION
An iceprod user reported issues connecting to the API, which were resolved after deleting the old refresh token.  It appeared to be expired and was failing to refresh.

This PR attempts to refresh the saved token, and if that fails will then initiate the device code process.