### PR TITLE
reduce logging noise

### DIFF
--- a/dependencies-dev.log
+++ b/dependencies-dev.log
@@ -82,7 +82,7 @@ typing-extensions==4.7.1
     #   wipac-dev-tools
 urllib3==2.0.4
     # via requests
-wheel==0.41.0
+wheel==0.41.1
     # via wipac-rest-tools (setup.py)
 wipac-dev-tools==1.6.16
     # via wipac-rest-tools (setup.py)

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -168,7 +168,7 @@ typing-extensions==4.7.1
     #   wipac-telemetry
 urllib3==2.0.4
     # via requests
-wheel==0.41.0
+wheel==0.41.1
     # via wipac-rest-tools (setup.py)
 wipac-dev-tools==1.6.16
     # via

--- a/rest_tools/client/client.py
+++ b/rest_tools/client/client.py
@@ -91,13 +91,13 @@ class CalcRetryFromWaittimeMax:
 def _log_retries_values(
     retries: int, timeout: float, backoff_factor: float, logger: logging.Logger
 ) -> None:
-    logger.info(f"using {retries=} {timeout=} {backoff_factor=}")
+    logger.debug(f"using {retries=} {timeout=} {backoff_factor=}")
     if retries:
         retries_schema = ' '.join(
             [f'<0.0s> {timeout}s']
             + [f'<{(backoff_factor * 2**i)}s> {timeout}s' for i in range(1, retries)]
         )
-        logger.info(
+        logger.debug(
             f"retry scheme (TIMEOUT [<BACKOFF> TIMEOUT ...]): "
             f"{timeout}s {retries_schema}"
         )

--- a/rest_tools/utils/auth.py
+++ b/rest_tools/utils/auth.py
@@ -142,7 +142,7 @@ class OpenIDAuth(_AuthValidate):
             for jwk in r.json()['keys']:
                 logging.debug(f'jwk: {jwk}')
                 kid = jwk['kid']
-                logging.info(f'loaded JWT key {kid}')
+                logging.debug(f'loaded JWT key {kid}')
                 self.public_keys[kid] = jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(jwk))
         except Exception:
             logging.warning('failed to refresh OpenID keys', exc_info=True)


### PR DESCRIPTION
It's annoying and distracting to see things like this when a large number of scripts using rest-tools are executed one after another in a loop:
```
INFO:root:loaded JWT key XXX
INFO:ClientCredentialsAuth:using retries=10 timeout=10.0 backoff_factor=0.3
INFO:ClientCredentialsAuth:retry scheme (TIMEOUT [<BACKOFF> TIMEOUT ...]): 10.0s <0.0s> 10.0s <0.6s> 10.0s <1.2s> 10.0s <2.4s> 10.0s <4.8s> 10.0s <9.6s> 10.0s <19.2s> 10.0s <38.4s> 10.0s <76.8s> 10.0s <153.6s> 10.0s
```

It seems like this information is too low-level for INFO log level. Can we switch it to debug?