### PR TITLE
Turn Down Logging for Auth Failures

### DIFF
--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -26,11 +26,11 @@ colorama==0.4.6
     # via crayons
 coloredlogs==15.0.1
     # via wipac-telemetry
-coverage[toml]==7.6.2
+coverage[toml]==7.6.3
     # via pytest-cov
 crayons==0.4.0
     # via pycycle
-cryptography==43.0.1
+cryptography==43.0.3
     # via pyjwt
 deprecated==1.2.14
     # via
@@ -41,7 +41,7 @@ googleapis-common-protos==1.59.1
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.66.2
+grpcio==1.67.0
     # via opentelemetry-exporter-jaeger-proto-grpc
 httpretty==1.1.4
     # via wipac-rest-tools (setup.py)
@@ -72,7 +72,7 @@ jsonschema-specifications==2023.12.1
     #   openapi-schema-validator
 lazy-object-proxy==1.10.0
     # via openapi-spec-validator
-markupsafe==3.0.1
+markupsafe==3.0.2
     # via
     #   jinja2
     #   werkzeug
@@ -186,7 +186,7 @@ thrift==0.21.0
     # via opentelemetry-exporter-jaeger-thrift
 tornado==6.4.1
     # via wipac-rest-tools (setup.py)
-types-requests==2.32.0.20240914
+types-requests==2.32.0.20241016
     # via wipac-rest-tools (setup.py)
 typing-extensions==4.12.2
     # via
@@ -204,7 +204,7 @@ wipac-dev-tools==1.13.0
     # via
     #   wipac-rest-tools (setup.py)
     #   wipac-telemetry
-wipac-telemetry==0.3.0
+wipac-telemetry==0.3.1
     # via wipac-rest-tools (setup.py)
 wrapt==1.16.0
     # via deprecated

--- a/dependencies-openapi.log
+++ b/dependencies-openapi.log
@@ -16,7 +16,7 @@ cffi==1.17.1
     # via cryptography
 charset-normalizer==3.4.0
     # via requests
-cryptography==43.0.1
+cryptography==43.0.3
     # via pyjwt
 idna==3.10
     # via requests
@@ -37,7 +37,7 @@ jsonschema-specifications==2023.12.1
     #   openapi-schema-validator
 lazy-object-proxy==1.10.0
     # via openapi-spec-validator
-markupsafe==3.0.1
+markupsafe==3.0.2
     # via werkzeug
 more-itertools==10.5.0
     # via openapi-core

--- a/dependencies-telemetry.log
+++ b/dependencies-telemetry.log
@@ -14,7 +14,7 @@ charset-normalizer==3.4.0
     # via requests
 coloredlogs==15.0.1
     # via wipac-telemetry
-cryptography==43.0.1
+cryptography==43.0.3
     # via pyjwt
 deprecated==1.2.14
     # via
@@ -25,7 +25,7 @@ googleapis-common-protos==1.59.1
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.66.2
+grpcio==1.67.0
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs
@@ -101,7 +101,7 @@ wipac-dev-tools==1.13.0
     # via
     #   wipac-rest-tools (setup.py)
     #   wipac-telemetry
-wipac-telemetry==0.3.0
+wipac-telemetry==0.3.1
     # via wipac-rest-tools (setup.py)
 wrapt==1.16.0
     # via deprecated

--- a/dependencies-tests.log
+++ b/dependencies-tests.log
@@ -20,11 +20,11 @@ click-completion==0.5.2
     # via pycycle
 colorama==0.4.6
     # via crayons
-coverage[toml]==7.6.2
+coverage[toml]==7.6.3
     # via pytest-cov
 crayons==0.4.0
     # via pycycle
-cryptography==43.0.1
+cryptography==43.0.3
     # via pyjwt
 httpretty==1.1.4
     # via wipac-rest-tools (setup.py)
@@ -34,7 +34,7 @@ iniconfig==2.0.0
     # via pytest
 jinja2==3.1.4
     # via click-completion
-markupsafe==3.0.1
+markupsafe==3.0.2
     # via jinja2
 packaging==24.1
     # via pytest
@@ -77,7 +77,7 @@ six==1.16.0
     # via click-completion
 tornado==6.4.1
     # via wipac-rest-tools (setup.py)
-types-requests==2.32.0.20240914
+types-requests==2.32.0.20241016
     # via wipac-rest-tools (setup.py)
 typing-extensions==4.12.2
     # via wipac-dev-tools

--- a/dependencies.log
+++ b/dependencies.log
@@ -12,7 +12,7 @@ cffi==1.17.1
     # via cryptography
 charset-normalizer==3.4.0
     # via requests
-cryptography==43.0.1
+cryptography==43.0.3
     # via pyjwt
 idna==3.10
     # via requests

--- a/rest_tools/server/handler.py
+++ b/rest_tools/server/handler.py
@@ -31,7 +31,7 @@ LOGGER = logging.getLogger('rest')
 
 
 def _log_auth_failed(e: Exception):
-    LOGGER.warning('failed auth')
+    LOGGER.info('failed auth')
     if LOGGER.isEnabledFor(logging.DEBUG):
         LOGGER.exception(e)
 

--- a/rest_tools/server/handler.py
+++ b/rest_tools/server/handler.py
@@ -1,8 +1,6 @@
 """RestHandler and related classes."""
 
-
 # fmt:off
-# pylint: skip-file
 
 import base64
 import functools
@@ -14,7 +12,6 @@ import urllib.parse
 from collections import defaultdict
 from typing import Any, Dict, Union
 
-import rest_tools
 import tornado.escape
 import tornado.gen
 import tornado.httpclient
@@ -22,14 +19,21 @@ import tornado.httputil
 import tornado.web
 from tornado.auth import OAuth2Mixin
 
+import rest_tools
+from .decorators import catch_error
+from .stats import RouteStats
 from .. import telemetry as wtt
 from ..utils.auth import Auth, OpenIDAuth
 from ..utils.json_util import json_decode
 from ..utils.pkce import PKCEMixin
-from .decorators import catch_error
-from .stats import RouteStats
 
 LOGGER = logging.getLogger('rest')
+
+
+def _log_auth_failed(e: Exception):
+    LOGGER.warning('failed auth')
+    if LOGGER.isEnabledFor(logging.DEBUG):
+        LOGGER.exception(e)
 
 
 def RestHandlerSetup(config={}):
@@ -148,10 +152,10 @@ class RestHandler(tornado.web.RequestHandler):
             self.auth_key = token
             return data['sub']
         # Auth Failed
-        except Exception:
+        except Exception as e:
             if self.debug and 'Authorization' in self.request.headers:
                 LOGGER.info('Authorization: %r', self.request.headers['Authorization'])
-            LOGGER.info('failed auth', exc_info=True)
+            _log_auth_failed(e)
 
         return None
 
@@ -282,8 +286,8 @@ class OpenIDCookieHandlerMixin:
             self.auth_refresh_token = refresh_token
             return data['sub']
         # Auth Failed
-        except Exception:
-            LOGGER.debug('failed auth', exc_info=True)
+        except Exception as e:
+            _log_auth_failed(e)
 
         return None
 


### PR DESCRIPTION
Bots normally hit the index path routinely (`/`). This should always fail due to invalid auth. However, this bloats the logs due to the current logging scheme.

Example:
```
2024-10-18 13:27:18.952 [   DEBUG] skydriver-rest-7f975b4f94-z7v29 rest[1] GET [MainHandler] <handler.py:172/prepare()>
2024-10-18 13:27:18.952 [   DEBUG] skydriver-rest-7f975b4f94-z7v29 root[1] routestats: [0.0005822181701660156, 0.0006031990051269531, 0.0007824897766113281] <stats.py:63/is_overloaded()>
2024-10-18 13:27:18.952 [    INFO] skydriver-rest-7f975b4f94-z7v29 rest[1] failed auth <handler.py:165/get_current_user()>
Traceback (most recent call last):
  File "/home/app/.local/lib/python3.11/site-packages/rest_tools/server/handler.py", line 153, in get_current_user
    type, token = self.request.headers['Authorization'].split(' ', 1)
                  ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/app/.local/lib/python3.11/site-packages/tornado/httputil.py", line 216, in __getitem__
    return self._dict[_normalize_header(name)]
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'Authorization'
2024-10-18 13:27:18.952 [ WARNING] skydriver-rest-7f975b4f94-z7v29 root[1] 403 GET / (10.42.2.126) 1.41ms <server.py:27/tornado_logger()>
2024-10-18 13:27:19.080 [    INFO] skydriver-rest-7f975b4f94-z7v29 tornado.general[1] Malformed HTTP message from 10.42.2.126: Malformed HTTP version in HTTP Request-Line: 'HTTP/2.0' <http1connection.py:292/_read_message()>
```

This PR removes the stack trace unless the "rest" logger is enabled for "debug" (at least).