### PR TITLE
`ArgumentHandler`: Support Custom Validation Errors

### DIFF
--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -26,7 +26,7 @@ colorama==0.4.6
     # via crayons
 coloredlogs==15.0.1
     # via wipac-telemetry
-coverage[toml]==7.6.8
+coverage[toml]==7.6.9
     # via pytest-cov
 crayons==0.4.0
     # via pycycle

--- a/dependencies-tests.log
+++ b/dependencies-tests.log
@@ -20,7 +20,7 @@ click-completion==0.5.2
     # via pycycle
 colorama==0.4.6
     # via crayons
-coverage[toml]==7.6.8
+coverage[toml]==7.6.9
     # via pytest-cov
 crayons==0.4.0
     # via pycycle

--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -147,7 +147,7 @@ class ArgumentHandler:
         captured_stderr: str,
     ) -> str:
         """Translate argparse-style error to a message str for HTTPError."""
-        LOGGER.error(f"Intercepted error and translating to requestor: {exc}")
+        LOGGER.error(f"Intercepted error to translate for requestor: {exc}")
 
         # errors not covered by 'exit_on_error=False' (in __init__)
         if isinstance(exc, (SystemExit, argparse.ArgumentError)):

--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -237,4 +237,4 @@ class ArgumentHandler:
                 captured_stderr = f.getvalue()
         # handle exception outside of context manager so *this* stderr is not intercepted
         msg = self._translate_error(exc, captured_stderr)
-        raise tornado.web.HTTPError(400, log_message=msg, reason=msg)
+        raise tornado.web.HTTPError(400, reason=msg)

--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -147,6 +147,7 @@ class ArgumentHandler:
         captured_stderr: str,
     ) -> str:
         """Translate argparse-style error to a message str for HTTPError."""
+        LOGGER.error(f"Intercepted error and translating to requestor: {exc}")
 
         # errors not covered by 'exit_on_error=False' (in __init__)
         if isinstance(exc, (SystemExit, argparse.ArgumentError)):

--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -98,25 +98,31 @@ class ArgumentHandler:
     ) -> None:
         """Add an argument -- `argparse.add_argument` with minimal additions.
 
-        No `--`-prefix is needed.
+        Do not include a `--`-prefix on the `name`.
 
         See https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.add_argument
 
-        Note: Built-in validation errors, like using the `choices` param and others,
-              is forwarded as 400 response from the argparse validation message.
+        ### Built-in Validation
+        Validation errors built into `argparse`, such as those triggered
+        by the `choices` parameter, are forwarded as `400 Bad Request`
+        responses. These responses include the corresponding validation
+        message from `argparse`.
 
-        Note: Many types of validation exceptions are parsed and relayed as
-              400 responses, if the `type` param is a callable that raises
-              an exception.
-                > HOWEVER, if you want the 400 response to include
-                  a custom validation message, raise `argparse.ArgumentTypeError(...)`.
-                  Otherwise, the 400 will have a generic message, for
-                  example, 'argument foo: invalid type'.
+        ### `type`-Validation
+        Many types of validation exceptions are also handled and returned
+        as `400 Bad Request` responses if the `type` parameter is a callable
+        that raises an exception.
+            > HOWEVER, to include a custom validation message in the
+              `400 Bad Request` response, you must raise an
+              `argparse.ArgumentTypeError(...)`. Otherwise, the
+              `400 Bad Request` response will contain a generic
+              message, such as 'argument myarg: invalid type'.
 
-        Note: Not all of `argparse.add_argument`'s parameters make sense
-              for key-value based arguments, such as flag-oriented
-              options. Nevertheless, no given parameters are excluded,
-              just make sure to test it first :)
+        ### Note
+        Not all of `argparse.add_argument`'s parameters make sense
+        for key-value based arguments, such as flag-oriented
+        options. Nevertheless, no given parameters are excluded,
+        just make sure to test it first :)
         """
 
         def retrieve_json_body_arg(parsed_val: Any) -> Any:

--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -102,6 +102,17 @@ class ArgumentHandler:
 
         See https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.add_argument
 
+        Note: Built-in validation errors, like using the `choices` param and others,
+              is forwarded as 400 response from the argparse validation message.
+
+        Note: Many types of validation exceptions are parsed and relayed as
+              400 responses, if the `type` param is a callable that raises
+              an exception.
+                > HOWEVER, if you want the 400 response to include
+                  a custom validation message, raise `argparse.ArgumentTypeError(...)`.
+                  Otherwise, the 400 will have a generic message, for
+                  example, 'argument foo: invalid type'.
+
         Note: Not all of `argparse.add_argument`'s parameters make sense
               for key-value based arguments, such as flag-oriented
               options. Nevertheless, no given parameters are excluded,
@@ -197,6 +208,7 @@ class ArgumentHandler:
                 return match.group(1).replace("--", "")
 
             # CATCH MOST (not quite 'catch all') -- covers errors in this known format
+            # -> this is matched when the server code raises argparse.ArgumentTypeError
             elif match := CATCH_MOST_PATTERN.search(err_msg):
                 return match.group(1).replace("--", "")
 

--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -62,7 +62,7 @@ INVALID_VALUE_PATTERN = re.compile(r"(argument .+: invalid) .+ value: '.+'")
 INVALID_CHOICE_PATTERN = re.compile(r"(argument .+: invalid choice: .+)")
 
 # argument --reco_algo: cannot be empty string / whitespace
-CATCH_MOST_PATTERN = re.compile(r"(argument .+: .+)")
+FROM_ARGUMENT_TYPE_ERROR_PATTERN = re.compile(r"(argument .+: .+)")
 
 
 ###############################################################################
@@ -213,9 +213,9 @@ class ArgumentHandler:
             elif match := INVALID_CHOICE_PATTERN.search(err_msg):
                 return match.group(1).replace("--", "")
 
-            # CATCH MOST (not quite 'catch all') -- covers errors in this known format
+            # argparse.ArgumentTypeError errors -- covers errors in this known format
             # -> this is matched when the server code raises argparse.ArgumentTypeError
-            elif match := CATCH_MOST_PATTERN.search(err_msg):
+            elif match := FROM_ARGUMENT_TYPE_ERROR_PATTERN.search(err_msg):
                 return match.group(1).replace("--", "")
 
         # FALL-THROUGH -- log unknown exception

--- a/rest_tools/server/arghandler.py
+++ b/rest_tools/server/arghandler.py
@@ -150,7 +150,7 @@ class ArgumentHandler:
         captured_stderr: str,
     ) -> str:
         """Translate argparse-style error to a message str for HTTPError."""
-        LOGGER.error(f"Intercepted error to translate for requestor: {exc}")
+        LOGGER.error(f"Intercepted error to translate for requestor -> {exc}")
 
         # errors not covered by 'exit_on_error=False' (in __init__)
         if isinstance(exc, (SystemExit, argparse.ArgumentError)):

--- a/tests/unit_server/arghandler_test.py
+++ b/tests/unit_server/arghandler_test.py
@@ -712,12 +712,11 @@ def test_241__argparse_custom_validation__argumenttypeerror__error(
         arghand.add_argument(
             arg,
             type=_error_it,
+            # NOTE: ^^^ because this takes no arguments (isn't a lambda),
+            #       argparse treats it like any other error. why? idk :/
         )
 
     with pytest.raises(tornado.web.HTTPError) as e:
         arghand.parse_args()
 
-    assert (
-        str(e.value)
-        == "HTTP 400: argument foo: it's a bad value and you *will* see this!"
-    )
+    assert str(e.value) == "HTTP 400: argument foo: invalid type"

--- a/tests/unit_server/arghandler_test.py
+++ b/tests/unit_server/arghandler_test.py
@@ -540,15 +540,21 @@ def test_220__argparse_nargs(argument_source: str) -> None:
     test_130__duplicates(argument_source)
 
 
+class MyError(Exception):
+    """Used below."""
+
+
 @pytest.mark.parametrize(
     "argument_source",
     [QUERY_ARGUMENTS, JSON_BODY_ARGUMENTS],
 )
 @pytest.mark.parametrize(
     "exc",
-    [TypeError, ValueError, argparse.ArgumentTypeError, argparse.ArgumentError],
+    [TypeError, ValueError, argparse.ArgumentError, RuntimeError, IndexError, MyError],
 )
-def test_230__argparse_catch_most__error(argument_source: str, exc: Exception) -> None:
+def test_230__argparse_custom_validation__error(
+    argument_source: str, exc: Exception
+) -> None:
     """Test `argument_source` arguments using argparse's advanced options."""
     args: Dict[str, Any] = {
         "foo": "True",
@@ -574,11 +580,53 @@ def test_230__argparse_catch_most__error(argument_source: str, exc: Exception) -
             arg,
             type=lambda x: _error_it(
                 x,
-                exc("it's a bad value"),  # type: ignore
+                exc("it's a bad value but you won't see this message anyway..."),  # type: ignore
             ),
         )
 
     with pytest.raises(tornado.web.HTTPError) as e:
         arghand.parse_args()
 
-    assert str(e.value) == "HTTP 400: argument foo: it's a bad value"
+    assert str(e.value) == "HTTP 400: argument foo: invalid type"
+
+
+@pytest.mark.parametrize(
+    "argument_source",
+    [QUERY_ARGUMENTS, JSON_BODY_ARGUMENTS],
+)
+def test_235__argparse_custom_validation__argumenttypeerror__error(
+    argument_source: str,
+) -> None:
+    """Test `argument_source` arguments using argparse's advanced options."""
+    args: Dict[str, Any] = {
+        "foo": "True",
+    }
+    if argument_source == JSON_BODY_ARGUMENTS:
+        args = {
+            "foo": [1, 2, 3],
+        }
+
+    # set up ArgumentHandler
+    arghand = setup_argument_handler(
+        argument_source,
+        args,
+    )
+
+    def _error_it():
+        raise argparse.ArgumentTypeError("it's a bad value and you *will* see this!")
+
+    for arg, _ in args.items():
+        print()
+        print(arg)
+        arghand.add_argument(
+            arg,
+            type=_error_it,
+        )
+
+    with pytest.raises(tornado.web.HTTPError) as e:
+        arghand.parse_args()
+
+    assert (
+        str(e.value)
+        == "HTTP 400: argument foo: it's a bad value and you *will* see this!"
+    )

--- a/tests/unit_server/arghandler_test.py
+++ b/tests/unit_server/arghandler_test.py
@@ -10,7 +10,7 @@ import pytest
 import requests
 import tornado.web
 from tornado import httputil
-from wipac_dev_tools import strtobool
+from wipac_dev_tools import argparse_tools, strtobool
 
 from rest_tools.server.arghandler import ArgumentHandler, ArgumentSource
 from rest_tools.server.handler import RestHandler
@@ -564,13 +564,17 @@ def test_230__argparse_catch_most__error(argument_source: str, exc: Exception) -
         args,
     )
 
-    def _error_now():
-        raise exc("it's a bad value")
-
     for arg, _ in args.items():
         print()
         print(arg)
-        arghand.add_argument(arg, type=_error_now)
+        arghand.add_argument(
+            arg,
+            type=lambda x: argparse_tools.validate_arg(
+                x,
+                False,  # always error
+                exc("it's a bad value"),
+            ),
+        )
 
     with pytest.raises(tornado.web.HTTPError) as e:
         arghand.parse_args()

--- a/tests/unit_server/arghandler_test.py
+++ b/tests/unit_server/arghandler_test.py
@@ -669,7 +669,7 @@ def test_240__argparse_custom_validation__argumenttypeerror__error(
         print(arg)
         arghand.add_argument(
             arg,
-            type=lambda x: _error_it(x),
+            type=_error_it,
         )
 
     with pytest.raises(tornado.web.HTTPError) as e:

--- a/tests/unit_server/arghandler_test.py
+++ b/tests/unit_server/arghandler_test.py
@@ -564,11 +564,7 @@ def test_230__argparse_catch_most__error(argument_source: str, exc: Exception) -
         args,
     )
 
-    def _validate(val: Any, test: bool, exc: Exception):
-        if test:
-            return val
-        if not isinstance(exc, argparse.ArgumentTypeError):
-            raise argparse.ArgumentTypeError(f"{repr(exc)} [{val}]")
+    def _error_it(_: Any, exc: Exception):
         raise exc
 
     for arg, _ in args.items():
@@ -576,9 +572,8 @@ def test_230__argparse_catch_most__error(argument_source: str, exc: Exception) -
         print(arg)
         arghand.add_argument(
             arg,
-            type=lambda x: _validate(
+            type=lambda x: _error_it(
                 x,
-                False,  # always error
                 exc("it's a bad value"),  # type: ignore
             ),
         )

--- a/tests/unit_server/arghandler_test.py
+++ b/tests/unit_server/arghandler_test.py
@@ -1,7 +1,6 @@
 """Test server/arghandler.py."""
 
-# pylint: disable=W0212,W0621
-
+import argparse
 import json
 import sys
 from typing import Any, Dict, List, Tuple, Union, cast
@@ -15,6 +14,8 @@ from wipac_dev_tools import strtobool
 
 from rest_tools.server.arghandler import ArgumentHandler, ArgumentSource
 from rest_tools.server.handler import RestHandler
+
+# pylint: disable=W0212,W0621
 
 # these tests are only for 3.9+
 if sys.version_info < (3, 9):
@@ -543,7 +544,11 @@ def test_220__argparse_nargs(argument_source: str) -> None:
     "argument_source",
     [QUERY_ARGUMENTS, JSON_BODY_ARGUMENTS],
 )
-def test_230__argparse_catch_most__error(argument_source: str) -> None:
+@pytest.mark.parametrize(
+    "exc",
+    [TypeError, ValueError, argparse.ArgumentTypeError, argparse.ArgumentError],
+)
+def test_230__argparse_catch_most__error(argument_source: str, exc: Exception) -> None:
     """Test `argument_source` arguments using argparse's advanced options."""
     args: Dict[str, Any] = {
         "bar": "True",
@@ -560,7 +565,7 @@ def test_230__argparse_catch_most__error(argument_source: str) -> None:
     )
 
     def _error_now():
-        raise TypeError("it's a bad value")
+        raise exc("it's a bad value")
 
     for arg, _ in args.items():
         print()

--- a/tests/unit_server/arghandler_test.py
+++ b/tests/unit_server/arghandler_test.py
@@ -643,7 +643,49 @@ def test_231__argparse_custom_validation__unsupported_errors__error(
     "argument_source",
     [QUERY_ARGUMENTS, JSON_BODY_ARGUMENTS],
 )
-def test_235__argparse_custom_validation__argumenttypeerror__error(
+def test_240__argparse_custom_validation__argumenttypeerror__error(
+    argument_source: str,
+) -> None:
+    """Test `argument_source` arguments using argparse's advanced options."""
+    args: Dict[str, Any] = {
+        "foo": "True",
+    }
+    if argument_source == JSON_BODY_ARGUMENTS:
+        args = {
+            "foo": [1, 2, 3],
+        }
+
+    # set up ArgumentHandler
+    arghand = setup_argument_handler(
+        argument_source,
+        args,
+    )
+
+    def _error_it(_: Any):
+        raise argparse.ArgumentTypeError("it's a bad value and you *will* see this!")
+
+    for arg, _ in args.items():
+        print()
+        print(arg)
+        arghand.add_argument(
+            arg,
+            type=lambda x: _error_it(x),
+        )
+
+    with pytest.raises(tornado.web.HTTPError) as e:
+        arghand.parse_args()
+
+    assert (
+        str(e.value)
+        == "HTTP 400: argument foo: it's a bad value and you *will* see this!"
+    )
+
+
+@pytest.mark.parametrize(
+    "argument_source",
+    [QUERY_ARGUMENTS, JSON_BODY_ARGUMENTS],
+)
+def test_241__argparse_custom_validation__argumenttypeerror__error(
     argument_source: str,
 ) -> None:
     """Test `argument_source` arguments using argparse's advanced options."""

--- a/tests/unit_server/arghandler_test.py
+++ b/tests/unit_server/arghandler_test.py
@@ -549,7 +549,7 @@ def test_220__argparse_nargs(argument_source: str) -> None:
     "exc",
     [TypeError, ValueError, argparse.ArgumentError],
 )
-def test_230__argparse_custom_validation__error(
+def test_230__argparse_custom_validation__supported_builtins__error(
     argument_source: str, exc: Exception
 ) -> None:
     """Test `argument_source` arguments using argparse's advanced options."""
@@ -599,7 +599,7 @@ class MyError(Exception):
     "exc",
     [RuntimeError, IndexError, MyError],
 )
-def test_231__argparse_custom_validation__unsupported_errors__error(
+def test_232__argparse_custom_validation__unsupported_errors__error(
     argument_source: str, exc: Exception
 ) -> None:
     """Test `argument_source` arguments using argparse's advanced options."""
@@ -643,7 +643,7 @@ def test_231__argparse_custom_validation__unsupported_errors__error(
     "argument_source",
     [QUERY_ARGUMENTS, JSON_BODY_ARGUMENTS],
 )
-def test_240__argparse_custom_validation__argumenttypeerror__error(
+def test_234__argparse_custom_validation__argumenttypeerror__error(
     argument_source: str,
 ) -> None:
     """Test `argument_source` arguments using argparse's advanced options."""
@@ -685,8 +685,21 @@ def test_240__argparse_custom_validation__argumenttypeerror__error(
     "argument_source",
     [QUERY_ARGUMENTS, JSON_BODY_ARGUMENTS],
 )
-def test_241__argparse_custom_validation__argumenttypeerror__error(
+@pytest.mark.parametrize(
+    "exc",
+    [  # all the exceptions!
+        TypeError,
+        ValueError,
+        argparse.ArgumentError,
+        argparse.ArgumentTypeError,
+        RuntimeError,
+        IndexError,
+        MyError,
+    ],
+)
+def test_236__argparse_custom_validation__validator_no_param__error(
     argument_source: str,
+    exc: Exception,
 ) -> None:
     """Test `argument_source` arguments using argparse's advanced options."""
     args: Dict[str, Any] = {
@@ -703,16 +716,16 @@ def test_241__argparse_custom_validation__argumenttypeerror__error(
         args,
     )
 
-    def _error_it():
-        raise argparse.ArgumentTypeError("it's a bad value and you *will* see this!")
+    def _error_it__no_param():
+        raise exc("it's a bad value and you *will* see this!")  # type: ignore
 
     for arg, _ in args.items():
         print()
         print(arg)
         arghand.add_argument(
             arg,
-            type=_error_it,
-            # NOTE: ^^^ because this takes no arguments (isn't a lambda),
+            type=_error_it__no_param,
+            # NOTE: ^^^ because this takes no arguments (isn't a func/lambda),
             #       argparse treats it like any other error. why? idk :/
         )
 

--- a/tests/unit_server/arghandler_test.py
+++ b/tests/unit_server/arghandler_test.py
@@ -572,7 +572,7 @@ def test_230__argparse_catch_most__error(argument_source: str, exc: Exception) -
             type=lambda x: argparse_tools.validate_arg(
                 x,
                 False,  # always error
-                exc("it's a bad value"),
+                exc("it's a bad value"),  # type: ignore=[operator]
             ),
         )
 


### PR DESCRIPTION
### `type`-Validation
        Many types of validation exceptions are also handled and returned
        as `400 Bad Request` responses if the `type` parameter is a callable
        that raises an exception.
            > HOWEVER, to include a custom validation message in the
              `400 Bad Request` response, you must raise an
              `argparse.ArgumentTypeError(...)`. Otherwise, the
              `400 Bad Request` response will contain a generic
              message, such as 'argument myarg: invalid type'.