### PR TITLE
Quiet Down OpenAPI Error Logging (in CI)

### DIFF
--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -25,7 +25,7 @@ jobs:
 
   lint:
     needs: [ py-versions ]
-    uses: WIPACrepo/wipac-dev-workflows/.github/workflows/lint-python.yml@v1.21
+    uses: WIPACrepo/wipac-dev-workflows/.github/workflows/lint-python.yml@v1.26
     with:
       py-matrix-json: ${{ needs.py-versions.outputs.matrix }}
       max-complexity: 16  # ideal is ~10-15
@@ -187,7 +187,7 @@ jobs:
       tests-with-openapi
       #      tests-with-telemetry  # removed for now
     ]
-    uses: WIPACrepo/wipac-dev-workflows/.github/workflows/tag-and-release.yml@v1.20
+    uses: WIPACrepo/wipac-dev-workflows/.github/workflows/tag-and-release.yml@v1.26
     permissions: # for GITHUB_TOKEN
       contents: write
     with:

--- a/examples/rest_client.py
+++ b/examples/rest_client.py
@@ -8,7 +8,7 @@ import logging
 
 from rest_tools.client import RestClient  # noqa: E402 # pylint: disable=C0413,E0401
 from rest_tools.utils import Auth  # noqa: E402 # pylint: disable=C0413,E0401
-from wipac_telemetry import tracing_tools  # type: ignore[import]
+from wipac_telemetry import tracing_tools  # type: ignore[import]  # ty: ignore[unresolved-import]
 
 
 @tracing_tools.spanned()

--- a/examples/rest_server.py
+++ b/examples/rest_server.py
@@ -16,7 +16,7 @@ from rest_tools.server import (  # noqa: E402 # pylint: disable=C0413,E0401
 from rest_tools.utils.json_util import (  # noqa: E402 # pylint: disable=C0413,E0401
     json_decode,
 )
-from wipac_telemetry import tracing_tools  # type: ignore[import]
+from wipac_telemetry import tracing_tools  # type: ignore[import]  # # ty: ignore[unresolved-import]
 
 
 class FruitsHanlder(RestHandler):

--- a/rest_tools/client/client.py
+++ b/rest_tools/client/client.py
@@ -259,7 +259,7 @@ class RestClient:
                 self.logger.debug('token expired')
 
         try:
-            self.access_token = self.token_func()  # type: ignore[misc]
+            self.access_token = self.token_func()  # type: ignore[misc]  # ty: ignore[call-non-callable]
         except Exception:
             self.logger.warning('acquiring access token failed')
             raise
@@ -276,7 +276,7 @@ class RestClient:
             args = {}
 
         # auto-inject the current span's info into the HTTP headers
-        wtt.inject_span_carrier_if_recording(self.session.headers)  # type: ignore[arg-type]
+        wtt.inject_span_carrier_if_recording(self.session.headers)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
         if path.startswith('/'):
             path = path[1:]
@@ -343,7 +343,7 @@ class RestClient:
         url, kwargs = self._prepare(method, path, args, headers)
         try:
             # session: AsyncSession; So, self.session.request() -> Future
-            r: requests.Response = await asyncio.wrap_future(self.session.request(method, url, **kwargs))  # type: ignore[arg-type]
+            r: requests.Response = await asyncio.wrap_future(self.session.request(method, url, **kwargs))  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
             r.raise_for_status()
             return self._decode(r.content)
         except requests.exceptions.HTTPError as e:

--- a/rest_tools/openapi_tools.py
+++ b/rest_tools/openapi_tools.py
@@ -248,7 +248,7 @@ async def request_and_validate(
     url, kwargs = rc._prepare(method, path, args=args)
 
     # run request as async in case of other dependent, concurrent actions (ex: test suite runs server in same process)
-    response = await asyncio.wrap_future(rc.session.request(method, url, **kwargs))  # type: ignore[var-annotated,arg-type]
+    response = await asyncio.wrap_future(rc.session.request(method, url, **kwargs))  # type: ignore[var-annotated,arg-type]  # ty: ignore[invalid-argument-type]
 
     try:
         openapi_spec.validate_response(

--- a/rest_tools/openapi_tools.py
+++ b/rest_tools/openapi_tools.py
@@ -178,7 +178,10 @@ def validate_request(openapi_spec: "openapi_core.OpenAPI"):  # type: ignore
                     reason = str(e)  # to client
                 if os.getenv("CI"):
                     # in prod, don't fill up logs w/ traces from invalid data
-                    LOGGER.exception(e)
+                    LOGGER.exception(
+                        f"Request data is invalid (will send 400 error): "
+                        f"{e.__class__.__name__}: {e}"
+                    )
                 raise tornado.web.HTTPError(
                     status_code=400,
                     log_message=f"{e.__class__.__name__}: {e}",  # to stderr

--- a/rest_tools/openapi_tools.py
+++ b/rest_tools/openapi_tools.py
@@ -178,7 +178,7 @@ def validate_request(openapi_spec: "openapi_core.OpenAPI"):  # type: ignore
                     reason = str(e)  # to client
                 if os.getenv("CI"):
                     # in prod, don't fill up logs w/ traces from invalid data
-                    LOGGER.exception(
+                    LOGGER.error(
                         f"Request data is invalid (will send 400 error): "
                         f"{e.__class__.__name__}: {e}"
                     )

--- a/rest_tools/telemetry.py
+++ b/rest_tools/telemetry.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Optional, TypeVar, cast
 # First, try to import then implement wipac-telemetry
 #
 try:
-    import wipac_telemetry.tracing_tools as wtt  # type: ignore[import]  # ignore for CI/CD
+    import wipac_telemetry.tracing_tools as wtt  # type: ignore[import]  # ty: ignore[unresolved-import]  # ignore for CI/CD
 
     evented = wtt.evented
     spanned = wtt.spanned

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,0 @@
-"""Setup."""
-
-
-from setuptools import setup  # type: ignore[import]  # mypy error in GH Action
-
-setup()

--- a/tests/integrate_openapi/request_and_validate_test.py
+++ b/tests/integrate_openapi/request_and_validate_test.py
@@ -26,7 +26,7 @@ async def server(port: int) -> AsyncIterator[Callable[[], RestClient]]:
     class TestHandler(RestHandler):
         ROUTE = "/echo/this"
 
-        async def post(self) -> None:
+        async def post(self) -> None:  # ty: ignore[invalid-method-override]
             if self.get_argument("raise", None):
                 raise tornado.web.HTTPError(self.get_argument("raise"), "it's an error")
             self.write({"resp-echo": self.get_argument("echo", {})})


### PR DESCRIPTION
When the `CI` env var is defined, IOW we're running GHA tests, we log OpenAPI exceptions for request data validation. This results in overly deep stack traces. Let's quiet this down a bit.

This eliminates ~50 lines per error.

## Other
A few updates for ty: add "ignores" and rm `setup.py`.