### PR TITLE
validate token before getting scope

### DIFF
--- a/rest_tools/client/openid_client.py
+++ b/rest_tools/client/openid_client.py
@@ -65,7 +65,7 @@ class OpenIDRestClient(RestClient):
 
     def _get_scopes(self) -> str:
         try:
-            return jwt.decode(self.refresh_token, options={'verify_signature': False}).get('scope', '')
+            return self.auth.validate(self.refresh_token, audience=None).get('scope', '')
         except jwt.exceptions.DecodeError:
             # in case the token is opaque
             return ''

--- a/tests/unit_client/openid_client_test.py
+++ b/tests/unit_client/openid_client_test.py
@@ -71,7 +71,8 @@ def make_auth(well_known_mock, requests_mock: Mock):
     yield auth
 
 
-def test_10_scopes(make_auth, requests_mock: Mock) -> None:
+def test_scopes(make_auth, requests_mock: Mock) -> None:
+    """Test that we can get scopes from the refresh token"""
     initial_refresh_token = make_auth.create_token('xxx', payload={'scope':'foo'}, headers={'kid': 'test-key'})
 
     def token_response(req: PreparedRequest, ctx: Any) -> bytes:  # pylint: disable=W0613
@@ -90,7 +91,8 @@ def test_10_scopes(make_auth, requests_mock: Mock) -> None:
     assert s == 'foo'
 
 
-def test_10_scopes_opaque_token(make_auth, requests_mock: Mock) -> None:
+def test_scopes_opaque_token(make_auth, requests_mock: Mock) -> None:
+    """Test that we fail over gracefully for opaque tokens that are not jwt"""
     initial_refresh_token = make_auth.create_token('xxx', payload={'scope':'foo'}, headers={'kid': 'test-key'})
 
     def token_response(req: PreparedRequest, ctx: Any) -> bytes:  # pylint: disable=W0613
@@ -100,7 +102,7 @@ def test_10_scopes_opaque_token(make_auth, requests_mock: Mock) -> None:
         assert body['client_id'][0] == 'client-id'
         return json_encode({
             "access_token": make_auth.create_token('sub', headers={'kid': 'test-key'}),
-            "refresh_token": 'my_fake_token',
+            "refresh_token": 'my_opaque_token',
         }).encode("utf-8")
     requests_mock.post('http://test/token', content=token_response)
 
@@ -110,10 +112,11 @@ def test_10_scopes_opaque_token(make_auth, requests_mock: Mock) -> None:
     assert s == ''
 
 
-def test_10_scopes_invalid_alg(make_auth, requests_mock: Mock) -> None:
+def test_scopes_invalid_alg(make_auth, requests_mock: Mock) -> None:
+    """Test that we get an exception if we get a bad jwt"""
     initial_refresh_token = make_auth.create_token('xxx', payload={'scope':'foo'}, headers={'kid': 'test-key'})
 
-    fake_auth = Auth('secret'*20)
+    bad_auth = Auth('secret'*20)
 
     def token_response(req: PreparedRequest, ctx: Any) -> bytes:  # pylint: disable=W0613
         assert req.body is not None
@@ -122,7 +125,7 @@ def test_10_scopes_invalid_alg(make_auth, requests_mock: Mock) -> None:
         assert body['client_id'][0] == 'client-id'
         return json_encode({
             "access_token": make_auth.create_token('sub', headers={'kid': 'test-key'}),
-            "refresh_token": fake_auth.create_token('xxx', payload={'scope':'foo'}, headers={'kid': 'test-key'}),
+            "refresh_token": bad_auth.create_token('xxx', payload={'scope':'foo'}, headers={'kid': 'test-key'}),
         }).encode("utf-8")
     requests_mock.post('http://test/token', content=token_response)
 

--- a/tests/unit_client/openid_client_test.py
+++ b/tests/unit_client/openid_client_test.py
@@ -114,9 +114,8 @@ def test_scopes_opaque_token(make_auth, requests_mock: Mock) -> None:
 
 def test_scopes_invalid_alg(make_auth, requests_mock: Mock) -> None:
     """Test that we get an exception if we get a bad jwt"""
-    initial_refresh_token = make_auth.create_token('xxx', payload={'scope':'foo'}, headers={'kid': 'test-key'})
-
     bad_auth = Auth('secret'*20)
+    initial_refresh_token = bad_auth.create_token('xxx', payload={'scope':'foo'}, headers={'kid': 'test-key'})
 
     def token_response(req: PreparedRequest, ctx: Any) -> bytes:  # pylint: disable=W0613
         assert req.body is not None

--- a/tests/unit_client/openid_client_test.py
+++ b/tests/unit_client/openid_client_test.py
@@ -117,18 +117,6 @@ def test_scopes_invalid_alg(make_auth, requests_mock: Mock) -> None:
     bad_auth = Auth('secret'*20)
     initial_refresh_token = bad_auth.create_token('xxx', payload={'scope':'foo'}, headers={'kid': 'test-key'})
 
-    def token_response(req: PreparedRequest, ctx: Any) -> bytes:  # pylint: disable=W0613
-        assert req.body is not None
-        body = urllib.parse.parse_qs(str(req.body))
-        logging.debug('token request args: %r', body)
-        assert body['client_id'][0] == 'client-id'
-        return json_encode({
-            "access_token": make_auth.create_token('sub', headers={'kid': 'test-key'}),
-            "refresh_token": bad_auth.create_token('xxx', payload={'scope':'foo'}, headers={'kid': 'test-key'}),
-        }).encode("utf-8")
-    requests_mock.post('http://test/token', content=token_response)
-
-    rc = OpenIDRestClient('http://test-api', 'http://test', refresh_token=initial_refresh_token, client_id='client-id')
-
+    # fails initially because of the call to _get_scopes in the __init__
     with pytest.raises(jwt.exceptions.InvalidAlgorithmError):
-        rc._get_scopes()
+        OpenIDRestClient('http://test-api', 'http://test', refresh_token=initial_refresh_token, client_id='client-id')

--- a/tests/unit_client/openid_client_test.py
+++ b/tests/unit_client/openid_client_test.py
@@ -4,6 +4,7 @@ import urllib.parse
 from typing import Any
 from unittest.mock import Mock
 
+import jwt
 import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -36,7 +37,8 @@ def to_base64url(n):
     return base64.urlsafe_b64encode(der_bytes).decode('utf-8').rstrip('=')
 
 
-def test_10_scopes(well_known_mock, requests_mock: Mock) -> None:
+@pytest.fixture
+def make_auth(well_known_mock, requests_mock: Mock):
     private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
     priv_pem = private_key.private_bytes(
         encoding=serialization.Encoding.PEM,
@@ -59,13 +61,18 @@ def test_10_scopes(well_known_mock, requests_mock: Mock) -> None:
         ]
     }
 
-    # auth for making tokens
-    auth = Auth(secret=priv_pem, algorithm='RS256')
-    initial_refresh_token = auth.create_token('xxx', payload={'scope':'foo'}, headers={'kid': 'test-key'})
-
     def jwks_response(req: PreparedRequest, ctx: Any) -> bytes:  # pylint: disable=W0613
         return json_encode(jwks).encode("utf-8")
     requests_mock.get('http://test/jwks', content=jwks_response)
+
+    # auth for making tokens
+    auth = Auth(secret=priv_pem, algorithm='RS256')
+
+    yield auth
+
+
+def test_10_scopes(make_auth, requests_mock: Mock) -> None:
+    initial_refresh_token = make_auth.create_token('xxx', payload={'scope':'foo'}, headers={'kid': 'test-key'})
 
     def token_response(req: PreparedRequest, ctx: Any) -> bytes:  # pylint: disable=W0613
         assert req.body is not None
@@ -73,11 +80,53 @@ def test_10_scopes(well_known_mock, requests_mock: Mock) -> None:
         logging.debug('token request args: %r', body)
         assert body['client_id'][0] == 'client-id'
         return json_encode({
-            "access_token": auth.create_token('sub', headers={'kid': 'test-key'}),
-            "refresh_token": auth.create_token('xxx', payload={'scope':'foo'}, headers={'kid': 'test-key'}),
+            "access_token": make_auth.create_token('sub', headers={'kid': 'test-key'}),
+            "refresh_token": make_auth.create_token('xxx', payload={'scope':'foo'}, headers={'kid': 'test-key'}),
         }).encode("utf-8")
     requests_mock.post('http://test/token', content=token_response)
 
     rc = OpenIDRestClient('http://test-api', 'http://test', refresh_token=initial_refresh_token, client_id='client-id')
     s = rc._get_scopes()
     assert s == 'foo'
+
+
+def test_10_scopes_opaque_token(make_auth, requests_mock: Mock) -> None:
+    initial_refresh_token = make_auth.create_token('xxx', payload={'scope':'foo'}, headers={'kid': 'test-key'})
+
+    def token_response(req: PreparedRequest, ctx: Any) -> bytes:  # pylint: disable=W0613
+        assert req.body is not None
+        body = urllib.parse.parse_qs(str(req.body))
+        logging.debug('token request args: %r', body)
+        assert body['client_id'][0] == 'client-id'
+        return json_encode({
+            "access_token": make_auth.create_token('sub', headers={'kid': 'test-key'}),
+            "refresh_token": 'my_fake_token',
+        }).encode("utf-8")
+    requests_mock.post('http://test/token', content=token_response)
+
+    rc = OpenIDRestClient('http://test-api', 'http://test', refresh_token=initial_refresh_token, client_id='client-id')
+
+    s = rc._get_scopes()
+    assert s == ''
+
+
+def test_10_scopes_invalid_alg(make_auth, requests_mock: Mock) -> None:
+    initial_refresh_token = make_auth.create_token('xxx', payload={'scope':'foo'}, headers={'kid': 'test-key'})
+
+    fake_auth = Auth('secret'*20)
+
+    def token_response(req: PreparedRequest, ctx: Any) -> bytes:  # pylint: disable=W0613
+        assert req.body is not None
+        body = urllib.parse.parse_qs(str(req.body))
+        logging.debug('token request args: %r', body)
+        assert body['client_id'][0] == 'client-id'
+        return json_encode({
+            "access_token": make_auth.create_token('sub', headers={'kid': 'test-key'}),
+            "refresh_token": fake_auth.create_token('xxx', payload={'scope':'foo'}, headers={'kid': 'test-key'}),
+        }).encode("utf-8")
+    requests_mock.post('http://test/token', content=token_response)
+
+    rc = OpenIDRestClient('http://test-api', 'http://test', refresh_token=initial_refresh_token, client_id='client-id')
+
+    with pytest.raises(jwt.exceptions.InvalidAlgorithmError):
+        rc._get_scopes()

--- a/tests/unit_client/openid_client_test.py
+++ b/tests/unit_client/openid_client_test.py
@@ -93,7 +93,7 @@ def test_scopes(make_auth, requests_mock: Mock) -> None:
 
 def test_scopes_opaque_token(make_auth, requests_mock: Mock) -> None:
     """Test that we fail over gracefully for opaque tokens that are not jwt"""
-    initial_refresh_token = make_auth.create_token('xxx', payload={'scope':'foo'}, headers={'kid': 'test-key'})
+    initial_refresh_token = 'my_opaque_token'
 
     def token_response(req: PreparedRequest, ctx: Any) -> bytes:  # pylint: disable=W0613
         assert req.body is not None

--- a/tests/unit_client/openid_client_test.py
+++ b/tests/unit_client/openid_client_test.py
@@ -1,0 +1,82 @@
+import base64
+import logging
+from typing import Any
+from unittest.mock import Mock
+import urllib.parse
+
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import serialization
+import pytest
+from requests import PreparedRequest
+
+from rest_tools.client import OpenIDRestClient
+from rest_tools.utils.auth import Auth
+from rest_tools.utils.json_util import json_encode  # isort:skip # noqa # pylint: disable=C0413
+
+
+@pytest.fixture
+def well_known_mock(requests_mock: Mock):
+    result = {
+        'token_endpoint': 'http://test/token',
+        'jwks_uri': 'http://test/jwks',
+    }
+
+    def response(req: PreparedRequest, ctx: Any) -> bytes:  # pylint: disable=W0613
+        return json_encode(result).encode("utf-8")
+    requests_mock.get("http://test/.well-known/openid-configuration", content=response)
+
+
+def to_base64url(n):
+    """Converts an integer to a Base64URL-encoded string without padding."""
+    # Convert integer to bytes (big-endian)
+    byte_length = (n.bit_length() + 7) // 8
+    der_bytes = n.to_bytes(byte_length, byteorder='big')
+    # Encode and remove padding '='
+    return base64.urlsafe_b64encode(der_bytes).decode('utf-8').rstrip('=')
+
+
+def test_10_scopes(well_known_mock, requests_mock: Mock) -> None:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    priv_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_numbers = private_key.public_key().public_numbers()
+
+    # Build the JWK manually using n and e
+    jwks = {
+        "keys": [
+            {
+                "kty": "RSA",
+                "kid": "test-key",         # Key ID for rotation/lookup
+                "use": "sig",              # Key usage (signing)
+                "alg": "RS256",            # Algorithm
+                "n": to_base64url(public_numbers.n), # Modulus as hex
+                "e": to_base64url(public_numbers.e), # Exponent as hex
+            }
+        ]
+    }
+
+    # auth for making tokens
+    auth = Auth(secret=priv_pem, algorithm='RS256')
+    initial_refresh_token = auth.create_token('xxx', payload={'scope':'foo'}, headers={'kid': 'test-key'})
+
+    def jwks_response(req: PreparedRequest, ctx: Any) -> bytes:  # pylint: disable=W0613
+        return json_encode(jwks).encode("utf-8")
+    requests_mock.get('http://test/jwks', content=jwks_response)
+
+    def token_response(req: PreparedRequest, ctx: Any) -> bytes:  # pylint: disable=W0613
+        assert req.body is not None
+        body = urllib.parse.parse_qs(str(req.body))
+        logging.debug('token request args: %r', body)
+        assert body['client_id'][0] == 'client-id'
+        return json_encode({
+            "access_token": auth.create_token('sub', headers={'kid': 'test-key'}),
+            "refresh_token": auth.create_token('xxx', payload={'scope':'foo'}, headers={'kid': 'test-key'}),
+        }).encode("utf-8")
+    requests_mock.post('http://test/token', content=token_response)
+
+    rc = OpenIDRestClient('http://test-api', 'http://test', refresh_token=initial_refresh_token, client_id='client-id')
+    s = rc._get_scopes()
+    assert s == 'foo'

--- a/tests/unit_client/openid_client_test.py
+++ b/tests/unit_client/openid_client_test.py
@@ -1,16 +1,17 @@
 import base64
 import logging
+import urllib.parse
 from typing import Any
 from unittest.mock import Mock
-import urllib.parse
 
-from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.hazmat.primitives import serialization
 import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 from requests import PreparedRequest
 
 from rest_tools.client import OpenIDRestClient
 from rest_tools.utils.auth import Auth
+
 from rest_tools.utils.json_util import json_encode  # isort:skip # noqa # pylint: disable=C0413
 
 


### PR DESCRIPTION
SWAMP highlighted this error, which I thought was valid enough to fix.

Also, a test for the openid client code appears!